### PR TITLE
Add a responsive grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Try quiver out here: https://varkor.github.io/quiver
 ## Features
 - An intuitive graphical interface for creating and modifying commutative diagrams.
 - Support for objects, morphisms, natural transformations.
+- A responsive, resizable grid.
 - tikz-cd (LaTeX) export.
 - Shareable links.
 - Smart label alignment and edge offset.

--- a/src/dom.js
+++ b/src/dom.js
@@ -42,6 +42,11 @@ DOM.Element = class {
         return this;
     }
 
+    /// Removes the element from the DOM.
+    remove() {
+        this.element.remove();
+    }
+
     /// Adds an event listener.
     listen(type, f) {
         this.element.addEventListener(type, event => f(event, this.element));
@@ -54,6 +59,10 @@ DOM.Element = class {
             this.element.firstChild.remove();
         }
         return this;
+    }
+
+    query_selector(selector) {
+        return this.element.querySelector(selector);
     }
 };
 

--- a/src/ds.js
+++ b/src/ds.js
@@ -72,6 +72,11 @@ const Dimensions = class extends Position {
         return new Dimensions(0, 0);
     }
 
+    /// Returns a `Dimensions` with the same width and height.
+    static diag(x) {
+        return new Dimensions(x, x);
+    }
+
     get width() {
         return this.x;
     }
@@ -98,12 +103,50 @@ class Offset {
         return [`${this.left}px`, `${this.top}px`];
     }
 
+    as_dim() {
+        return new Dimensions(this.left, this.top);
+    }
+
     /// Moves an `element` to the offset.
     reposition(element) {
         [element.style.left, element.style.top] = this.to_CSS();
     }
 
+    add(other) {
+        return new (this.constructor)(this.left + other.left, this.top + other.top);
+    }
+
     sub(other) {
         return new (this.constructor)(this.left - other.left, this.top - other.top);
+    }
+
+    neg() {
+        return new (this.constructor)(-this.left, -this.top);
+    }
+
+    div(divisor) {
+        return new (this.constructor)(this.left / divisor, this.top / divisor);
+    }
+
+    min(other) {
+        return new (this.constructor)(
+            Math.min(this.left, other.left),
+            Math.min(this.top, other.top)
+        );
+    }
+
+    max(other) {
+        return new (this.constructor)(
+            Math.max(this.left, other.left),
+            Math.max(this.top, other.top)
+        );
+    }
+
+    length() {
+        return Math.hypot(this.left, this.top);
+    }
+
+    angle() {
+        return Math.atan2(this.top, this.left);
     }
 }

--- a/src/main.css
+++ b/src/main.css
@@ -5,8 +5,6 @@
 }
 
 :root {
-    /* Cell attributes. */
-    --cell-size: 64px;
     /* Cell states. */
     --cell-hover: hsla(0, 0%, 0%, 0.1);
     --cell-selected: hsla(0, 0%, 0%, 0.2);
@@ -118,14 +116,12 @@ body:not(.modal) {
 .insertion-point {
     display: block;
     position: absolute;
-    width: calc(var(--cell-size) - 2px); height: calc(var(--cell-size) - 2px);
-    transform: translate(-50%, -50%);
+    margin-left: 1px; margin-top: 1px;
 
     background: hsla(0, 0%, 0%, 0);
 
     text-align: center;
     font: 16px sans-serif;
-    line-height: var(--cell-size);
     color: hsla(0, 0%, 0%, 0.4);
 }
 
@@ -150,8 +146,6 @@ body:not(.modal) {
 
 .vertex {
     position: absolute;
-    width: var(--cell-size); height: var(--cell-size);
-    transform: translate(-50%, -50%);
 }
 
 .ui.default .vertex {
@@ -160,11 +154,9 @@ body:not(.modal) {
 
 .vertex .content {
     position: absolute;
-    width: calc(var(--cell-size) / 2); height: calc(var(--cell-size) / 2);
-    left: calc(var(--cell-size) / 2); top: calc(var(--cell-size) / 2);
     transform: translate(-50%, -50%);
 
-    border-radius: 100%;
+    border-radius: 2px;
 
     text-align: center;
 }

--- a/src/main.css
+++ b/src/main.css
@@ -109,6 +109,10 @@ body:not(.modal) {
 
 /* Grid interaction */
 
+.grid {
+    pointer-events: none;
+}
+
 .grid.hidden {
     display: none;
 }

--- a/src/quiver.js
+++ b/src/quiver.js
@@ -657,10 +657,6 @@ QuiverImportExport.base64 = new class extends QuiverImportExport {
         assert_kind(vertices, "natural");
         assert(vertices <= cells.length, "invalid number of vertices");
 
-        // We want to centre the view on the diagram, so we take the range of all vertex offsets.
-        let min_offset = new Offset(Infinity, Infinity);
-        let max_offset = new Offset(-Infinity, -Infinity);
-        ui.pan_view(ui.body_offset().neg());
         // If we encounter errors while loading cells, we skip the malformed cell and try to
         // continue loading the diagram, but we want to report the errors we encountered afterwards,
         // to let the user know we were not entirely successful.
@@ -680,12 +676,7 @@ QuiverImportExport.base64 = new class extends QuiverImportExport {
                     assert_kind(y, "natural");
                     assert_kind(label, "string");
 
-                    const position = new Position(x, y);
-                    const offset = ui.centre_offset_from_position(position);
-                    const centre = ui.cell_centre_at_position(position);
-                    min_offset = min_offset.min(offset.sub(centre));
-                    max_offset = max_offset.max(offset.add(centre));
-                    const vertex = new Vertex(ui, label, position);
+                    const vertex = new Vertex(ui, label, new Position(x, y));
                     indices.push(vertex);
                 } else {
                     // This cell is an edge.
@@ -729,13 +720,7 @@ QuiverImportExport.base64 = new class extends QuiverImportExport {
         }
 
         // Centre the view on the quiver.
-        if (vertices > 0) {
-            const view_offset = new Offset(
-                document.body.offsetWidth - ui.panel.element.offsetWidth,
-                document.body.offsetHeight,
-            );
-            ui.pan_view(view_offset.sub(max_offset.sub(min_offset)).div(2));
-        }
+        ui.centre_view();
 
         // If the quiver is now nonempty, some toolbar actions will be available.
         ui.toolbar.update(ui);

--- a/src/quiver.js
+++ b/src/quiver.js
@@ -165,10 +165,10 @@ class Quiver {
     /// Currently, the supported formats are:
     /// - "tikz-cd"
     /// - "base64"
-    export(format) {
+    export(ui, format) {
         switch (format) {
             case "tikz-cd":
-                return QuiverExport.tikz_cd.export(this);
+                return QuiverExport.tikz_cd.export(this, ui);
             case "base64":
                 return QuiverImportExport.base64.export(this);
             default:
@@ -190,7 +190,7 @@ class QuiverImportExport extends QuiverExport {
 }
 
 QuiverExport.tikz_cd = new class extends QuiverExport {
-    export(quiver) {
+    export(quiver, ui) {
         let output = "";
 
         // Wrap tikz-cd code with `\begin{tikzcd} ... \end{tikzcd}`.
@@ -408,14 +408,14 @@ QuiverExport.tikz_cd = new class extends QuiverExport {
                             case "adjunction":
                                 label = "\"\\dashv\"";
                                 // Adjunction symbols should point in the direction of the arrow.
-                                angle = -edge.angle() * 180 / Math.PI;
+                                angle = -edge.angle(ui) * 180 / Math.PI;
                                 break;
                             case "corner":
                                 label = "\"\\lrcorner\"";
                                 label_parameters.push("very near start");
                                 // Round the angle to the nearest 45º, so that the corner always
                                 // appears aligned with horizontal, vertical or diagonal lines.
-                                angle = 45 - 45 * Math.round(4 * edge.angle() / Math.PI);
+                                angle = 45 - 45 * Math.round(4 * edge.angle(ui) / Math.PI);
                                 break;
                         }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -2141,7 +2141,7 @@ class Panel {
                 ui.switch_mode(new UIState.Modal());
 
                 // Get the encoding of the diagram.
-                const output = ui.quiver.export(format);
+                const output = ui.quiver.export(ui, format);
 
                 let export_pane;
                 if (this.export === null) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -497,6 +497,16 @@ class UI {
 
         this.element.addEventListener("mousedown", (event) => {
             if (event.button === 0) {
+                // Usually, if `Alt` or `Control` have been held we will have already switched to
+                // the Pan mode. However, if the window is not in focus, they will not have been
+                // detected, so we switch modes on mouse click.
+                if (this.in_mode(UIState.Default)) {
+                    if (event.altKey) {
+                        this.switch_mode(new UIState.Pan("Alt"));
+                    } else if (event.ctrlKey) {
+                        this.switch_mode(new UIState.Pan("Control"));
+                    }
+                }
                 if (this.in_mode(UIState.Pan)) {
                     // Hide the insertion point if it is visible.
                     this.element.querySelector(".insertion-point").classList.remove("revealed");


### PR DESCRIPTION
Currently, quiver will resize the content of cells in order to fit them within the 128×128-pixel cells. This is better than nothing, but often cell content can become unreadable, because the text becomes too small.

This PR changes the behaviour of quiver to add a responsive grid, which will resize to fit the cell content. This is a massive usability boost and matches the behaviour of tikz-cd, making the output more predictable.

![image](https://user-images.githubusercontent.com/3943692/75838602-4621a180-5dbe-11ea-964c-f197c9b8ca43.png)
A contrived example.

This should be almost ready to be merged; I just need to do more testing to make sure there are no remaining issues.

Fixes #7.