### PR TITLE
Don't show welcome message when embedded

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -1590,3 +1590,8 @@ label input[type="checkbox"]:checked::before {
 .ui.embedded a > .logo:hover {
     opacity: 0.4;
 }
+
+.ui.embedded #welcome-pane {
+    /* Don't show the welcome pane if the first time we are loaded is in embed mode. */
+    display: none;
+}


### PR DESCRIPTION
The welcome pane isn't very helpful when in embedded mode, since editing isn't supported, and the person probably just wants to look at the diagram. If someone first loads Quiver in an embed, and then uses the editor later, they will see the welcome pane at that point.