### PR TITLE
DEL: remove `Control` key to switch Pan mode

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -1852,7 +1852,6 @@ class UI {
         // Holding Option or Control triggers panning mode (and releasing ends panning mode).
         this.shortcuts.add([
             { key: "Alt", context: Shortcuts.SHORTCUT_PRIORITY.Always },
-            { key: "Control", context: Shortcuts.SHORTCUT_PRIORITY.Always },
         ], (event) => {
             if (this.in_mode(UIMode.Default)) {
                 this.switch_mode(new UIMode.Pan(event.key));


### PR DESCRIPTION
Using Control key will make some unexcepted behavior
On Windows: a few shortcuts where the prefix is `ctrl` will not work
On Mac: press `Control` and touch the thouchpad will always call the ContextMenu
I think we can just preserve the `AltKey` as pan mode switch