### PR TITLE
Implement a tikz-cd parser

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -172,6 +172,13 @@ DOM.Div = class extends DOM.Element {
     }
 };
 
+DOM.Code = class extends DOM.Element {
+    constructor(value, attributes = {}, style = {}) {
+        super("code", attributes, style);
+        this.add(value);
+    }
+};
+
 /// A class for conveniently dealing with SVGs.
 DOM.SVGElement = class extends DOM.Element {
     constructor(tag_name, attributes = {}, style = {}) {

--- a/src/index.html
+++ b/src/index.html
@@ -40,6 +40,7 @@
     <script type="text/javascript" src="quiver.js"></script>
     <script type="text/javascript" src="bezier.js"></script>
     <script type="text/javascript" src="arrow.js"></script>
+    <script type="text/javascript" src="parser.js"></script>
     <script type="text/javascript" src="ui.js"></script>
 </head>
 <body>

--- a/src/main.css
+++ b/src/main.css
@@ -73,7 +73,7 @@ noscript {
     padding: 8px 0;
 
     background: hsl(0, 50%, 50%);
-    color: white;
+    color: var(--ui-white);
 
     text-align: center;
 
@@ -188,14 +188,14 @@ kbd {
     z-index: 400;
 
     background: hsl(0, 0%, 10%);
-
-    transition: opacity 0.6s;
 }
 
 .loading-screen.hidden {
     opacity: 0;
 
     pointer-events: none;
+
+    transition: opacity 0.6s;
 }
 
 .loading-screen .logo {
@@ -443,10 +443,10 @@ being. */
     left: 50%;
     bottom: 0;
     transform: translateX(-50%);
-    width: 704px;
+    width: 808px;
     height: 46px;
     padding: 8px;
-    /* Display above the export pane. */
+    /* Display above the import/export pane. */
     z-index: 101;
 
     background: var(--ui-black);
@@ -579,7 +579,7 @@ label.inline {
 }
 
 .panel input[type="text"],
-.export .options input[type="number"] {
+.port .options input[type="number"] {
     padding: 2px 4px;
 
     background: var(--ui-background);
@@ -593,17 +593,17 @@ label.inline {
 }
 
 .panel input[type="text"]::placeholder,
-.export .options input[type="number"]::placeholder {
+.port .options input[type="number"]::placeholder {
     color: hsla(0, 0%, 100%, 0.4);
 }
 
 .panel input[type="text"]:hover:not(:disabled):not(:focus),
-.export .options input[type="number"]:hover:not(:disabled):not(:focus) {
+.port .options input[type="number"]:hover:not(:disabled):not(:focus) {
     background: var(--ui-hover);
 }
 
 .panel input[type="text"]:focus,
-.export .options input[type="number"]:focus {
+.port .options input[type="number"]:focus {
     background: var(--ui-focus);
     border-color: var(--ui-focus);
 
@@ -611,7 +611,7 @@ label.inline {
 }
 
 .panel input[type="text"]:focus::placeholder,
-.export .options input[type="number"]:focus::placeholder {
+.port .options input[type="number"]:focus::placeholder {
     color: hsla(0, 0%, 0%, 0.4);
 }
 
@@ -866,7 +866,7 @@ div.slider {
     border-color: var(--ui-blue);
 }
 
-.panel button, .pane button {
+.panel button, .pane button, .port button {
     position: relative;
     display: block;
     width: 100%; height: 30px;
@@ -887,7 +887,15 @@ div.slider {
     margin: 0;
 }
 
-.global button:first-of-type {
+.global button.short {
+    width: 56px;
+}
+
+.global button + label {
+    margin-left: 4px;
+}
+
+.global label + button {
     margin-right: 4px;
 }
 
@@ -895,11 +903,15 @@ div.slider {
     margin-left: 4px;
 }
 
-.panel button:hover:not(:disabled):not(:active), .pane button:hover:not(:disabled):not(:active) {
+.panel button:hover:not(:disabled):not(:active),
+.pane button:hover:not(:disabled):not(:active),
+.port button:hover:not(:disabled):not(:active) {
     background: var(--ui-hover);
 }
 
-.panel button:active, .pane button:active {
+.panel button:not(:disabled):not(:active):active,
+.pane button:not(:disabled):not(:active):active,
+.port button:not(:disabled):not(:active):active {
     background: var(--ui-active);
 }
 
@@ -1400,7 +1412,7 @@ button.flash {
 
 /* Modal elements */
 
-.export {
+.port {
     position: fixed;
     width: 100%; height: 100%;
     left: 0; top: 0;
@@ -1412,29 +1424,30 @@ button.flash {
     background: hsla(0, 0%, 10%, 0.8);
 
     backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
 }
 
-.export a {
+.port a {
     color: var(--ui-white);
 }
 
-.export .tip, .export .warning {
+.port .tip, .port div.warning, .port div.error {
     display: inline-block;
     width: 100%;
     padding: 8pt;
     margin-bottom: 8pt;
 
     border-radius: 2px;
+
+    cursor: default;
 }
 
-.export .tip {
+.port .tip {
     background: var(--ui-black);
 
     color: var(--ui-white);
 }
 
-.export .tip .update {
+.port .tip .update {
     padding: 0pt 4pt;
     padding-bottom: 1pt;
     margin-left: 4pt;
@@ -1446,25 +1459,37 @@ button.flash {
 	font-size: 10pt;
 }
 
-.export .warning {
-    background: hsla(50, 100%, 70%, 1);
+.port div.error {
+    color: var(--ui-white);
+    background: hsl(0, 50%, 50%);
 }
 
-.export .hidden {
-    display: none;
+.port div.warning {
+    background: hsl(50, 100%, 70%);
 }
 
-.export .warning ul {
+.port .hidden {
+    display: none !important;
+}
+
+.port div.error ul, .port div.warning ul {
     margin: 4pt 0;
 
     list-style-type: circle;
 }
 
-.export .warning a {
+.port.import div.error ul li:hover,
+.port.import div.error ul li.highlight,
+.port.import div.warning ul li:hover,
+.port.import div.warning ul li.highlight {
+    list-style-type: disc;
+}
+
+.port div.warning a {
     color: var(--ui-black);
 }
 
-.export .options {
+.port .options {
     margin-bottom: 8pt;
     padding: 6pt 4pt;
 
@@ -1476,13 +1501,13 @@ button.flash {
     user-select: none;
 }
 
-.export .options label {
+.port .options label {
     position: relative;
     top: 1px;
     margin-right: 20pt;
 }
 
-.export .note {
+.port .note {
     display: inline-block;
     width: 100%;
     padding: 8pt;
@@ -1496,12 +1521,16 @@ button.flash {
     user-select: none;
 }
 
-.export .options label kbd.hint {
+.port .note.hidden {
+    display: none;
+}
+
+.port .options label kbd.hint {
     /* Leave some space for the checkbox itself. */
     transform: translate(-50%, -50%);
 }
 
-.export .options input[type="number"] {
+.port .options input[type="number"] {
     width: 64px;
     margin-right: -12pt;
 }
@@ -1546,14 +1575,48 @@ label input[type="checkbox"]:checked::before {
     color: var(--ui-black);
 }
 
-.export .code {
+.port .code, .port div[contenteditable] {
     font: 16px monospace;
-    color: white;
+    color: var(--ui-white);
 
     white-space: pre-wrap;
     overflow-wrap: break-word;
     tab-size: 4;
     -moz-tab-size: 4;
+}
+
+.port div[contenteditable] {
+    width: 100%;
+    height: 252pt;
+    resize: none;
+    padding: 6pt 8pt;
+    overflow-y: auto;
+
+    background: hsla(0, 0%, 0%, 0.2);
+
+    border: none;
+    outline: none;
+}
+
+/* We pad empty fragments so that we can see their highlight. */
+.port .fragment:empty::before {
+    content: " ";
+}
+
+.port .fragment.error {
+    text-decoration: hsl(0, 50%, 50%) wavy underline;
+}
+.port .fragment.error:hover, .port .fragment.error.highlight {
+    background: hsl(0, 50%, 50%);
+}
+
+.port .fragment.warning {
+    text-decoration: hsl(50, 100%, 70%) wavy underline;
+}
+.port .fragment.warning:hover, .port .fragment.highlight.warning {
+    background: hsl(50, 100%, 70%);
+
+    color: var(--ui-black);
 }
 
 /* Arrows */

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,0 +1,955 @@
+/// This is a simple recursive descent parser for tikz-cd diagrams. The intention is to be able to
+/// parse those diagrams exported by quiver, in addition to a handful of other tikz-cd features that
+/// are commonly used in hand-written diagrams. Most of the implementation is dealing with errors
+/// nicely, e.g. issuing informative diagnostics. Note that we do not try to guarantee that
+/// exporting from quiver, then parsing the resulting tikz-cd will result in exactly the same
+/// diagram (though this is certainly something we would like to aim for): some of the techniques we
+/// use are heuristic-based (e.g. calculating lengths), and guaranteeing a perfect round-trip is not
+/// feasible.
+class Parser {
+    constructor(ui, code) {
+        this.ui = ui;
+        // `souce` is not changed.
+        this.source = code;
+        // `code` is changed as the parse proceeds: it is the remaining source to parse.
+        this.code = code;
+        // A list of errors and warnings to issue once the parse has concluded.
+        this.diagnostics = [];
+        // A map from cell names to cells.
+        this.cells = new Map();
+        // The current position to place new vertices.
+        this.x = 0;
+        this.y = 0;
+        // The string used to demark a new column. This may be changed by `ampersand replacement`.
+        this.col_delim = "&";
+    }
+
+    /// The current position of the parser in the `source` code.
+    get position() {
+        return this.source.length - this.code.length;
+    }
+
+    /// Returns a range starting from the specified position, to the currrent position.
+    range_from(start) {
+        return Parser.Range.from_to(start, this.position);
+    }
+
+    /// Returns a zero-width range at the current position. This is the default range when we don't
+    /// have better information about the range to associate with a diagnostic.
+    range_here() {
+        return this.range_from(this.position);
+    }
+
+    log(diagnostic) {
+        this.diagnostics.push(diagnostic);
+    }
+
+    // We use errors to exit early out of parsing at different stages. Any time an error or warning
+    // is caught, it is logged, and parsing resumes, if possible, after moving on to the next
+    // parseable segment.
+    // Every occurrence of `this.error` or `this.warn` should either be `this.log`ged, or thrown.
+    catch_and_log(f, on_error = () => {}) {
+        try {
+            f.apply(this);
+        } catch (diagnostic) {
+            if (diagnostic instanceof Parser.Error || diagnostic instanceof Parser.Warning) {
+                on_error.apply(this, [diagnostic]);
+                this.log(diagnostic);
+            } else {
+                // If we actually encounter a JavaScript error, we wish to log this in the console,
+                // not in the UI.
+                throw diagnostic;
+            }
+        }
+    }
+
+    error(message, range = this.range_here()) {
+        return new Parser.Error(message, range);
+    }
+
+    warn(message, range = this.range_here()) {
+        return new Parser.Warning(message, range);
+    }
+
+    /// Returns whether the parser has reached the end of the source.
+    is_finished() {
+        return this.code.length === 0;
+    }
+
+    /// The entrypoint for the parsing routine. Parses a tikz-cd diagram.
+    parse_diagram() {
+        this.catch_and_log(() => {
+            this.eat_whitespace_and_comments();
+            const in_block = this.eat("\\[") !== null;
+            this.eat_whitespace_and_comments();
+            if (!this.eat("\\begin{tikzcd}")) {
+                throw this.error(
+                    ["Diagrams must start with ", new DOM.Code("\\begin{tikzcd}"), "."],
+                    new Parser.Range(0, this.code.length),
+                );
+            }
+            this.catch_and_log(this.parse_diagram_options);
+            const parser_edges = [];
+
+            // A loop to parse cells (edges and nodes).
+            let [x, y] = [null, null];
+            while (true) {
+                this.eat_whitespace_and_comments();
+                let leaf;
+                if ((leaf = this.parse_edge()) !== null) {
+                    parser_edges.push(leaf);
+                    continue;
+                }
+                if (this.eat(this.col_delim)) {
+                    ++this.x;
+                    continue;
+                }
+                if (this.eat("\\\\")) {
+                    this.x = 0;
+                    ++this.y;
+                    continue;
+                }
+                let cont = false;
+                const position = this.position;
+                // Nodes must be parsed last, because they are greedy about what they consider to be
+                // an acceptable label, and so may parse an arrow as a node, for instance.
+                this.catch_and_log(() => {
+                    if ((leaf = this.parse_node()) !== null) {
+                        cont = true;
+                        if (this.x === x && this.y === y) {
+                            // If we haven't moved to a new position since the last node, throw an
+                            // error.
+                            throw this.error([
+                                "Expected ", new DOM.Code(this.col_delim),
+                                " or ", new DOM.Code("\\\\"), " between nodes."
+                            ], new Parser.Range(position, 0));
+                        }
+                        x = this.x, y = this.y;
+                        this.cells.set(`${leaf.position}`, leaf);
+                        this.ui.quiver.add(leaf);
+                    }
+                }, () => cont = true);
+                if (!cont) {
+                    break;
+                }
+            }
+            // quiver lays out non-edge aligned connections using phantom edges. These should not be
+            // treated as real edges that are rendered in quiver.
+            const phantoms = new Set();
+            const adjust_for_phantoms = (edge, end) => {
+                if (/^[0-9]+p$/.test(edge[end])) {
+                    const non_phantom = edge[end].slice(0, -1);
+                    if (this.cells.get(edge[end]).phantom && this.cells.has(non_phantom)) {
+                        phantoms.add(this.cells.get(edge[end]));
+                        edge.options.edge_alignment[end] = false;
+                        return non_phantom;
+                    }
+                }
+                return edge[end];
+            };
+            const edges = new Map();
+            for (const edge of parser_edges) {
+                // If the edge has invalid source or target, simply skip it, as a warning will
+                // already have been issued.
+                if (edge.source === null || edge.target === null) {
+                    continue;
+                }
+
+                const source = adjust_for_phantoms(edge, "source");
+                const target = adjust_for_phantoms(edge, "target");
+
+                // Create dummy vertices if there are none in place for the source/target.
+                if (!this.cells.has(`${source}`)) {
+                    this.cells.set(`${source}`, new Vertex(this.ui, "", source));
+                }
+                // If the target is undefined, it was never set (as opposed to being set to an
+                // invalid value).
+                if (typeof target === "undefined") {
+                    this.log(this.error("Encountered arrow with no target.", edge.range));
+                    continue;
+                }
+                if (`${target}` === `${source}`) {
+                    this.log(
+                        this.error("Encountered arrow with the same source and target.", edge.range)
+                    );
+                    continue;
+                }
+                if (!this.cells.has(`${target}`)) {
+                    this.cells.set(`${target}`, new Vertex(this.ui, "", target));
+                }
+                let source_cell = this.cells.get(`${source}`);
+                if (source_cell instanceof Parser.Edge) {
+                    source_cell = edges.get(source_cell);
+                }
+                let target_cell = this.cells.get(`${target}`);
+                if (target_cell instanceof Parser.Edge) {
+                    target_cell = edges.get(target_cell);
+                }
+                edges.set(edge, new Edge(
+                    this.ui, edge.label, source_cell, target_cell, edge.options, edge.label_colour
+                ));
+            }
+            // Remove any phantom edges. Currently, we only remove those edges that were confirmed
+            // to be those exported by quiver for a special purpose, not any edge with the `phantom`
+            // attribute.
+            for (const phantom of phantoms) {
+                this.ui.remove_cell(edges.get(phantom), this.ui.present);
+            }
+            this.ui.quiver.flush(this.ui.present);
+
+            // Update all the affected columns and rows.
+            delay(() => {
+                // After updating the grid, we shorten the arrows proportionally to their
+                // length.
+                for (const [parser_edge, edge] of edges) {
+                    try {
+                        // This multiplier is lifted from `QuiverImportExport.tikz_cd`.
+                        const multiplier = QuiverExport.CONSTANTS.TIKZ_HORIZONTAL_MULTIPLIER
+                        * QuiverExport.CONSTANTS.TIKZ_VERTICAL_MULTIPLIER
+                        / ((QuiverExport.CONSTANTS.TIKZ_HORIZONTAL_MULTIPLIER ** 2
+                                * Math.sin(edge.angle()) ** 2
+                        + QuiverExport.CONSTANTS.TIKZ_VERTICAL_MULTIPLIER ** 2
+                            * Math.cos(edge.angle()) ** 2) ** 0.5);
+
+                        const bezier = edge.arrow.bezier();
+                        const [start, end] = edge.arrow.find_endpoints();
+                        const arc_length = bezier.arc_length(end.t) - bezier.arc_length(start.t);
+                        const convert_length = (length) => {
+                            const ROUND_TO = 5;
+                            return clamp(0, Math.round(
+                                (length / (arc_length * multiplier) * 100) / ROUND_TO
+                            ) * ROUND_TO, 100);
+                        };
+
+                        edge.options.shorten.source = convert_length(parser_edge.shorten.source);
+                        edge.options.shorten.target = convert_length(parser_edge.shorten.target);
+                        if (edge.options.shorten.source + edge.options.shorten.target >= 100) {
+                            this.log(
+                                this.warn("Encountered arrow with zero length.", parser_edge.range)
+                            );
+                            // Reset the shortening.
+                            edge.options.shorten.source = 0;
+                            edge.options.shorten.target = 0;
+                        }
+                    } catch (_) {
+                        // If there's an error, we simply don't shorten.
+                    }
+                }
+            });
+
+            if (!this.eat("\\end{tikzcd}")) {
+                throw this.error(
+                    ["Diagrams must end with ", new DOM.Code("\\end{tikzcd}"), "."],
+                    new Parser.Range(0, this.source.length),
+                );
+            }
+            this.eat_whitespace_and_comments();
+            if (in_block) {
+                this.eat("\\]", true);
+            }
+            this.eat_whitespace_and_comments();
+            if (!this.is_finished()) {
+                throw this.error(
+                    "Unexpected content after diagram.",
+                    Parser.Range.from_to(this.position, this.source.length),
+                );
+            }
+        });
+    }
+
+    /// Eats a string or regex.
+    eat(pattern, expected = false) {
+        if (typeof pattern === "string") {
+            if (this.code.startsWith(pattern)) {
+                this.code = this.code.replace(pattern, "");
+                return pattern;
+            }
+        } else {
+            const match = this.code.match(pattern);
+            if (match !== null && match.index === 0) {
+                this.code = this.code.replace(pattern, "");
+                return match[0];
+            }
+        }
+        if (expected) {
+            throw this.error(["Expected ", new DOM.Code(pattern), "."]);
+        }
+        return null;
+    }
+
+    /// Checks whether a string or pattern is next in the source.
+    check(pattern) {
+        if (typeof pattern === "string") {
+            if (this.code.startsWith(pattern)) {
+                return true;
+            }
+        } else {
+            const match = this.code.match(pattern);
+            return match !== null && match.index === 0;
+        }
+    }
+
+    eat_whitespace() {
+        if (/^\s+/.test(this.code)) {
+            this.code = this.code.replace(/^\s+/, "");
+            return true;
+        }
+        return false;
+    }
+
+    eat_whitespace_and_comments() {
+        while (this.eat_whitespace() || this.parse_comment() !== null);
+    }
+
+    parse_nat(expected = false) {
+        if (/^[0-9+]/.test(this.code)) {
+            const nat = this.code.match(/^[0-9]+/)[0];
+            this.code = this.code.replace(/^[0-9]+/, "");
+            return parseInt(nat);
+        }
+        if (expected) {
+            throw this.error("Expected natural number.");
+        }
+        return null;
+    }
+
+    parse_int(expected = false) {
+        const negative = this.eat("-") !== null;
+        const nat = this.parse_nat();
+        if (nat !== null) {
+            return negative ? -nat : nat;
+        }
+        if (expected) {
+            throw this.error("Expected integer.");
+        }
+        return null;
+    }
+
+    parse_float(expected = false) {
+        const start = this.position;
+        const str = this.eat(/-?[0-9]*\.?[0-9]*/);
+        if (str === null) {
+            if (expected) {
+                throw this.error("Expected number.");
+            }
+            return null;
+        }
+        const float = parseFloat(str);
+        if (Number.isNaN(float)) {
+            throw this.error(
+                ["Expected number, found ", new DOM.Code(str), "."],
+                this.range_from(start),
+            );
+        }
+        return float;
+    }
+
+    parse_comment() {
+        if (/^%/.test(this.code)) {
+            const comment = this.code.match(/^%(.*)/)[1];
+            this.code = this.code.replace(/^%(.*)/, "");
+            return comment;
+        }
+        return null;
+    }
+
+    /// Issue a warning if there was an option that was not recognised, or if there were no more
+    /// options.
+    unknown_option_warning(regex, kind) {
+        const match = this.code.match(regex);
+        if (match !== null) {
+            const option = match[0];
+            const message = option.length > 0 ?
+                [`Unknown ${kind} option: `, new DOM.Code(option), "."] :
+                `Expected ${kind} option.`;
+            throw this.warn(
+                message,
+                new Parser.Range(this.position, match[0].length),
+            );
+        } else {
+            throw this.error(`Unexpected end of ${kind} options.`);
+        }
+    }
+
+    /// Parse the options in the square brackets in `\begin{tikzcd}[...]`.
+    parse_diagram_options() {
+        if (this.eat("[")) {
+            this.eat_whitespace();
+            if (!this.eat("]")) {
+                while (true) {
+                    this.catch_and_log(() => {
+                        this.parse_diagram_option();
+                    }, this.skip_to_comma_or_bracket(/^\}/));
+                    this.eat_whitespace();
+                    if (this.eat("]")) {
+                        break;
+                    }
+                    if (!this.eat(",")) {
+                        if (!this.is_finished()) {
+                            throw this.error(
+                                "Expected comma before the start of the next diagram option."
+                            );
+                        }
+                        break;
+                    }
+                    this.eat_whitespace();
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    parse_diagram_option() {
+        if (this.eat("ampersand replacement")) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            const col_delim = this.eat(/[^\s,\]]+/);
+            if (col_delim !== null) {
+                this.col_delim = col_delim;
+            } else {
+                throw this.error("Expected column delimiter.");
+            }
+            return;
+        }
+        if (this.eat("row sep") || this.eat("column sep") || this.eat("sep")) {
+            // We simply ignore these options.
+            this.eat_whitespace();
+            this.eat("=", true);
+            if (this.eat(/-?[0-9a-z\.]+/) === null) {
+                throw this.error("Expected separation amount.");
+            }
+            return;
+        }
+        if (this.eat("cramped")) {
+            // We simply ignore this option.
+            return;
+        }
+
+        // Throw a warning about an unknown option.
+        this.unknown_option_warning(/^[^,\]]*(?=[,\]])/, "diagram");
+    }
+
+    parse_name(expected) {
+        const name = this.eat(/[0-9a-z_\-]+/i);
+        if (name === null && expected) {
+            throw this.error("Expected name.");
+        }
+        return name;
+    }
+
+    parse_colour(expected = false) {
+        const start = this.position;
+        if (this.eat("{rgb,")) {
+            const s = this.parse_nat(true);
+            this.eat(":red,", true);
+            const r = this.parse_nat(true);
+            this.eat(";green,", true);
+            const g = this.parse_nat(true);
+            this.eat(";blue,", true);
+            const b = this.parse_nat(true);
+            this.eat("}", true);
+            if (s !== 255 || ![r, g, b].every((x) => x !== null && x >= 0 & x <= 255)) {
+                throw this.warn("Malformed colour specification.", this.range_from(start));
+            }
+            return Colour.from_rgba(r, g, b);
+        }
+        if (expected) {
+            throw this.error("Expected colour specification.");
+        }
+        return null;
+    }
+
+    parse_node() {
+        const start = this.position;
+        // We don't want to parse `\end{tikzcd}` as a node.
+        if (this.check("\\end")) {
+            return null;
+        }
+        let colour = null;
+        this.catch_and_log(() => {
+            if (this.eat("\\textcolor")) {
+                colour = this.parse_colour(true);
+            }
+        });
+        let label = null;
+        if (this.eat("{")) {
+            let brackets = 1;
+            let i;
+            for (i = 0; i <= this.code.length; ++i) {
+                if (this.code[i] === "{") {
+                    ++brackets;
+                }
+                if (this.code[i] === "}") {
+                    --brackets;
+                }
+                if (brackets === 0) {
+                    break;
+                }
+            }
+            if (brackets === 0) {
+                label = this.code.substr(0, i);
+                this.code = this.code.slice(i + 1);
+            }
+        } else if (/^\S+/.test(this.code)) {
+            label = this.code.match(/^\S+/)[0];
+            this.code = this.code.replace(/^\S+/, "");
+        }
+        if (label !== null) {
+            return new Vertex(
+                this.ui,
+                label,
+                new Position(this.x, this.y),
+                colour || Colour.black(),
+            );
+        }
+        if (colour !== null) {
+            throw this.error("Colour specification without node.", this.range_from(start));
+        }
+        return null;
+    }
+
+    /// Skip to the next option, ignoring any characters from the current position to then. Used for
+    /// error recovery.
+    skip_to_comma_or_bracket(brackets = null) {
+        return (diagnostic = null) => {
+            const start = this.position;
+            this.code = this.code.replace(/^[^,\]\}]*(?=[,\]\}])/, "");
+            const range = this.range_from(start);
+            if (brackets !== null) {
+                this.code = this.code.replace(brackets, "");
+            }
+            if (diagnostic !== null && diagnostic.range !== null) {
+                diagnostic.range = Parser.Range.from_to(diagnostic.range.start, range.end);
+            }
+            return range;
+        };
+    }
+
+    parse_edge() {
+        const start = this.position;
+        if (this.eat("\\ar")) {
+            this.eat("row");
+            this.eat("[", true);
+            const edge = new Parser.Edge(
+                new Position(this.x, this.y),
+                new Parser.Range(start, start),
+            );
+            this.eat_whitespace();
+            if (!this.eat("]")) {
+                while (true) {
+                    this.catch_and_log(() => {
+                        this.parse_edge_option(edge);
+                    }, this.skip_to_comma_or_bracket(/^\}/));
+                    this.eat_whitespace();
+                    if (this.eat("]")) {
+                        break;
+                    }
+                    if (!this.eat(",")) {
+                        if (!this.is_finished()) {
+                            throw this.error(
+                                "Expected comma before the start of the next arrow option."
+                            );
+                        }
+                        break;
+                    }
+                    this.eat_whitespace();
+                }
+            }
+            edge.range.length = this.position - edge.range.start;
+            return edge;
+        }
+        return null;
+    }
+
+    /// Parse the options in the square brackets in `\arrow[...]`.
+    parse_edge_option(edge) {
+        let start = this.position;
+        // We special case adjunctions, pullbacks, and barred arrows, since quiver encodes them in a
+        // certain way.
+        if (this.eat("\"\\dashv\"{anchor=center")) {
+            this.eat(/, rotate=-?\d+/);
+            this.eat("}", true);
+            edge.options.style.name = "adjunction";
+            return;
+        }
+        if (this.eat("\"\\lrcorner\"{anchor=center, pos=0.125")) {
+            this.eat(/, rotate=-?\d+/);
+            this.eat("}", true);
+            edge.options.style.name = "corner";
+            return;
+        }
+        if (this.eat("\"\\ulcorner\"{anchor=center, pos=0.125")) {
+            this.eat(/, rotate=-?\d+/);
+            this.eat("}", true);
+            edge.options.style.name = "corner-inverse";
+            return;
+        }
+        if (this.eat("\"\\shortmid\"{marking}")) {
+            edge.options.style.body.name = "barred";
+            return;
+        }
+        if (this.eat("phantom")) {
+            // Special behaviour for `phantom`, which is used by quiver for edge alignment.
+            edge.phantom = true;
+            // In case the edge is not used for a special purpose by quiver, we give sensible
+            // defaults.
+            edge.options.label_alignment = "centre";
+            edge.options.style.head.name = "none";
+            edge.options.style.body.name = "none";
+            edge.options.style.tail.name = "none";
+            return;
+        }
+        // Parse label.
+        if (this.eat("\"")) {
+            const label = this.eat(/[^"]*/);
+            this.eat("\"", true);
+            edge.label = label;
+            if (this.eat("'")) {
+                edge.options.label_alignment = "right";
+            }
+            if (this.eat("{")) {
+                this.eat_whitespace();
+                if (!this.eat("}")) {
+                    while (true) {
+                        this.catch_and_log(() => {
+                            this.parse_label_option(edge);
+                        }, this.skip_to_comma_or_bracket());
+                        this.eat_whitespace();
+                        if (this.eat("}")) {
+                            break;
+                        }
+                        if (!this.eat(",")) {
+                            if (!this.is_finished()) {
+                                throw this.error(
+                                    "Expected comma before the start of the next label option."
+                                );
+                            }
+                            break;
+                        }
+                        this.eat_whitespace();
+                    }
+                }
+            }
+            return;
+        }
+        // Parse relative target positioning.
+        let to;
+        if ((to = this.eat(/[urld]+(?=\s*[,\]])/))) {
+            const u = (to.match(/u/g) || []).length;
+            const r = (to.match(/r/g) || []).length;
+            const l = (to.match(/l/g) || []).length;
+            const d = (to.match(/d/g) || []).length;
+            edge.target = new Position(edge.source.x + r - l, edge.source.y + d - u);
+            return;
+        }
+        const parse_coord = () => {
+            this.eat_whitespace();
+            this.eat("=", true);
+            this.eat_whitespace();
+            if (/^[0-9]+-[0-9]+/.test(this.code)) {
+                const y = this.parse_int(true);
+                this.eat("-");
+                const x = this.parse_int(true);
+                return new Position(x - 1, y - 1);
+            } else {
+                start = this.position;
+                let name = this.parse_name(true);
+                if (!this.cells.has(name)) {
+                    this.log(this.error(
+                        ["No cell named ", new DOM.Code(name), "."],
+                        this.range_from(start),
+                    ));
+                    return null;
+                }
+                return name;
+            }
+        };
+        // Parse absolute source and target positioning.
+        if (this.eat("from")) {
+            edge.source = parse_coord();
+            if (edge.source === null) {
+                this.skip_to_comma_or_bracket(/^\}/)();
+            }
+            return;
+        }
+        if (this.eat("to")) {
+            edge.target = parse_coord();
+            if (edge.to === null) {
+                this.skip_to_comma_or_bracket(/^\}/)();
+            }
+            return;
+        }
+        // quiver does not yet support loops, but it is helpful to issue an informative warning.
+        if (this.eat("loop")) {
+            // Do not warn about not having a target.
+            edge.target = null;
+            throw this.warn(
+                ["Loops are not yet supported in ", new DOM.Element("b").add("quiver"), "."],
+                this.range_from(start),
+            );
+        }
+        if (this.eat("Rightarrow")) {
+            edge.options.level = 2;
+            return;
+        }
+        if (this.eat("scaling nfold")) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            this.eat_whitespace();
+            const start = this.position;
+            const nat = this.parse_nat(true);
+            if (nat !== null) {
+                edge.options.level = clamp(2, nat, CONSTANTS.MAXIMUM_CELL_LEVEL);
+                if (nat < 2 || nat > CONSTANTS.MAXIMUM_CELL_LEVEL) {
+                    throw this.warn(
+                        `Level must be between 2 and ${CONSTANTS.MAXIMUM_CELL_LEVEL}.`,
+                        this.range_from(start),
+                    );
+                }
+            }
+            return;
+        }
+        if (this.eat("curve")) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            this.eat_whitespace();
+            this.eat("{", true);
+            this.eat_whitespace();
+            this.eat("height", true);
+            this.eat_whitespace();
+            this.eat("=", true);
+            const curve = this.parse_int(true);
+            this.eat("pt", true);
+            this.eat_whitespace();
+            this.eat("}", true);
+            const factor = CONSTANTS.CURVE_HEIGHT
+                * QuiverExport.CONSTANTS.TIKZ_HORIZONTAL_MULTIPLIER;
+            edge.options.curve = Math.round(clamp(-5, curve / factor, 5));
+            return;
+        }
+        let neg;
+        neg = true;
+        if (this.eat("bend left") || ((neg = false) || this.eat("bend right"))) {
+            this.eat_whitespace();
+            let amount = 1;
+            if (this.eat("=")) {
+                this.eat_whitespace();
+                // Calculating the correct amount from the bend angle requires knowing the length of
+                // the edge, which requires rendering it. Since diagrams exported from quiver do
+                // not use `bend left` or `bend right`, we don't try to accurately compute the curve
+                // and instead simply the presence of `bend` as an indication of whether we should
+                // curve at all.
+                this.parse_int(true);
+            }
+            edge.options.curve = Math.round(clamp(-5, amount * (neg ? -1 : 1), 5));
+            return;
+        }
+        neg = true;
+        if (this.eat("shift left") || ((neg = false) || this.eat("shift right"))) {
+            this.eat_whitespace();
+            let amount = 1;
+            if (this.eat("=")) {
+                this.eat_whitespace();
+                amount = this.parse_int(true);
+            }
+            edge.options.offset = amount * (neg ? -1 : 1);
+            return;
+        }
+        if (this.eat("shorten <")) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            const length = this.parse_int(true);
+            edge.shorten.source = length;
+            this.eat("pt", true);
+            return;
+        }
+        if (this.eat("shorten >")) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            const length = this.parse_int(true);
+            edge.shorten.target = length;
+            this.eat("pt", true);
+            return;
+        }
+        // Body styles.
+        for (const style of ["dashed", "dotted", "squiggly"]) {
+            if (this.eat(style)) {
+                edge.options.style.body.name = style;
+                return;
+            }
+        }
+        if (this.eat("no body")) {
+            edge.options.style.body.name = "none";
+            return;
+        }
+        // Tail styles.
+        if (this.eat("maps to")) {
+            edge.options.style.tail.name = "maps to";
+            return;
+        }
+        if (this.eat("tail") || this.eat("2tail")) {
+            if (this.eat(" reversed")) {
+                edge.options.style.tail.name = "arrowhead";
+            } else {
+                edge.options.style.tail.name = "mono";
+            }
+            return;
+        }
+        if (this.eat("hook")) {
+            edge.options.style.tail.name = "hook";
+            edge.options.style.tail.side = this.eat("'") ? "bottom" : "top";
+            return;
+        }
+        // Head styles.
+        if (this.eat("no head")) {
+            edge.options.style.head.name = "none";
+            return;
+        }
+        if (this.eat("two heads")) {
+            edge.options.style.head.name = "epi";
+            return;
+        }
+        if (this.eat("harpoon")) {
+            edge.options.style.head.name = "harpoon";
+            edge.options.style.head.side = this.eat("'") ? "bottom" : "top";
+            return;
+        }
+        // Colour.
+        let ate_color;
+        if (this.eat("draw") || ((ate_color = true) && this.eat("color"))) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            this.eat_whitespace();
+            if (!ate_color && this.eat("none")) {
+                edge.options.style.head.name = "none";
+                edge.options.style.body.name = "none";
+                edge.options.style.tail.name = "none";
+                return;
+            }
+            const colour = this.parse_colour(true);
+            edge.options.colour = colour;
+            if (ate_color) {
+                edge.label_colour = colour;
+            }
+            return;
+        }
+
+        // The following options are deliberately ignored, because they are used by quiver in
+        // tikz-cd export for convenience.
+        if (this.eat("start anchor=center") || this.eat("end anchor=center")) {
+            return;
+        }
+
+        // The following options are deliberately ignored, because they are used in conjunction with
+        // `loop`, which we already warn about.
+        if (this.eat("distance")) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            this.eat_whitespace();
+            this.parse_float(true);
+            this.eat(/^(em|pt)/);
+            return;
+        }
+        if (this.eat("in") || this.eat("out")) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            this.parse_int(true);
+            return;
+        }
+
+        // Throw a warning about an unknown option.
+        this.unknown_option_warning(/^[^,\]]*(?=[,\]])/, "arrow");
+    }
+
+    /// Parse the options in the curly brackets in `\arrow["f"{...}]`.
+    parse_label_option(edge) {
+        if (this.eat("text")) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            this.eat_whitespace();
+            const colour = this.parse_colour(true);
+            edge.label_colour = colour;
+            return;
+        }
+        if (this.eat("name")) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            this.eat_whitespace();
+            this.cells.set(this.parse_name(true), edge);
+            return;
+        }
+        if (this.eat("description")) {
+            edge.options.label_alignment = "centre";
+            return;
+        }
+        if (this.eat("marking")) {
+            edge.options.label_alignment = "over";
+            return;
+        }
+        if (this.eat("pos")) {
+            this.eat_whitespace();
+            this.eat("=", true);
+            this.eat_whitespace();
+            const pos = this.parse_float(true);
+            edge.options.label_position = clamp(0, pos * 100, 100);
+            return;
+        }
+
+        // The following options are deliberately ignored, because they are used by quiver in
+        // tikz-cd export for convenience.
+        if (this.eat("inner sep=0") || this.eat("anchor=center")) {
+            return;
+        }
+
+        // Throw a warning about an unknown option.
+        this.unknown_option_warning(/^[^,\}]*(?=[,\}])/, "label");
+    }
+};
+
+/// Represents the essential information about an edge.
+Parser.Edge = class {
+    constructor(source, range) {
+        this.source = source;
+        // An undefined target is distinguished from one with `null` target. The former means that
+        // the target was never set; the latter means that the target was set, but was invalid.
+        this.target = undefined;
+        // The range of the string specifying the edge, used for diagnostics.
+        this.range = range;
+        this.options = Edge.default_options({ level: 1 });
+        this.label_colour = Colour.black();
+        this.shorten = { source: 0, target: 0 };
+        this.phantom = false;
+    }
+};
+
+Parser.Error = class {
+    constructor(message, range) {
+        this.message = message;
+        this.range = range;
+    }
+};
+
+Parser.Warning = class {
+    constructor(message, range) {
+        this.message = message;
+        this.range = range;
+    }
+};
+
+/// Ranges are used for diagnostics, to highlight the part of the source that is associated with an
+/// error or warning.
+Parser.Range = class {
+    constructor(start, length) {
+        this.start = start;
+        this.length = length;
+    }
+
+    get end() {
+        return this.start + this.length;
+    }
+
+    static from_to(start, end) {
+        return new Parser.Range(start, end - start);
+    }
+};

--- a/src/tests/parser.tex
+++ b/src/tests/parser.tex
@@ -1,0 +1,211 @@
+%%% Valid diagrams %%%
+
+\begin{tikzcd}
+	A & B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}
+
+\begin{tikzcd}
+	A \arrow[r] & B
+\end{tikzcd}
+
+\[\begin{tikzcd}[ampersand replacement=\&,cramped,column sep=large,row sep=2.25em]
+	A \& B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}\]
+
+\begin{tikzcd}
+	A & B
+	\arrow[color={rgb,255:red,214;green,92;blue,92}, from=1-1, to=1-2]
+\end{tikzcd}
+
+\begin{tikzcd}
+	\textcolor{rgb,255:red,214;green,92;blue,92}{A} & \textcolor{rgb,255:red,92;green,92;blue,214}{B}
+	\arrow["f"{text={rgb,255:red,92;green,214;blue,92}}, draw={rgb,255:red,214;green,214;blue,92}, from=1-1, to=1-2]
+\end{tikzcd}
+
+% These...
+\begin{tikzcd} % ...are...
+	A & B % ...several...
+	\arrow[from=1-1, to=1-2]
+	% ...comments.
+\end{tikzcd} % And...
+% Another.
+
+% https://q.uiver.app/?q=WzAsMTYsWzAsNSwiZmciXSxbMSw0LCIoZkkpZyJdLFsxLDYsImYoSWcpIl0sWzIsMywiKGYoZ2YpKWciXSxbMiw3LCJmKChnZilnKSJdLFszLDIsIigoZmcpZilnIl0sWzQsMSwiKElmKWciXSxbNSwwLCJmZyJdLFszLDgsImYoZyhmZykpIl0sWzQsOSwiZihnSSkiXSxbNSwxMCwiZmciXSxbNCw1LCIoZmcpKGZnKSJdLFs2LDIsIkkoZmcpIl0sWzYsOCwiKGZnKUkiXSxbNyw1LCJJSSJdLFs5LDUsIkkiXSxbMCwxLCJyXlxcYnVsbGV0MSIsMV0sWzEsMiwiYSJdLFswLDIsIjFsXlxcYnVsbGV0IiwxXSxbMSwzLCIoMVxcYmV0YSkxIiwyXSxbMyw0LCJhIiwwLHsiY3VydmUiOi0xfV0sWzIsNCwiMShcXGJldGExKSJdLFszLDUsImFeXFxidWxsZXQxIiwyXSxbNSw2LCIoXFxhbHBoYTEpMSIsMl0sWzYsNywibDEiLDJdLFs0LDgsIjFhIl0sWzgsOSwiMSgxYSkiXSxbOSwxMCwiMXIiXSxbNSwxMSwiYSIsMCx7ImN1cnZlIjotMn1dLFs4LDExLCJhXlxcYnVsbGV0IiwyLHsiY3VydmUiOjJ9XSxbNiwxMiwiYSIsMix7ImN1cnZlIjoyfV0sWzcsMTIsImxeXFxidWxsZXQiXSxbMTEsMTIsIlxcYWxwaGExIiwyLHsiY3VydmUiOjJ9XSxbMTAsMTMsInJeXFxidWxsZXQiLDJdLFs5LDEzLCJcXGFscGhhXlxcYnVsbGV0IiwwLHsiY3VydmUiOi0yfV0sWzExLDEzLCIxYSIsMCx7ImN1cnZlIjotMn1dLFsxMiwxNCwiMVxcYWxwaGEiLDAseyJjdXJ2ZSI6LTF9XSxbMTMsMTQsIlxcYWxwaGExIiwyLHsiY3VydmUiOjF9XSxbMTQsMTUsImwiLDAseyJjdXJ2ZSI6LTN9XSxbMTQsMTUsInIiLDIseyJjdXJ2ZSI6M31dLFs2LDExLCJcXGNvbmciLDEseyJjdXJ2ZSI6LTIsInN0eWxlIjp7ImJvZHkiOnsibmFtZSI6Im5vbmUifSwiaGVhZCI6eyJuYW1lIjoibm9uZSJ9fX1dLFs5LDExLCJcXGNvbmciLDEseyJjdXJ2ZSI6Miwic3R5bGUiOnsiYm9keSI6eyJuYW1lIjoibm9uZSJ9LCJoZWFkIjp7Im5hbWUiOiJub25lIn19fV0sWzEzLDEyLCJcXGNvbmciLDEseyJjdXJ2ZSI6LTIsInN0eWxlIjp7ImJvZHkiOnsibmFtZSI6Im5vbmUifSwiaGVhZCI6eyJuYW1lIjoibm9uZSJ9fX1dLFswLDcsIjEiLDAseyJjdXJ2ZSI6LTV9XSxbMCwxMCwiMSIsMix7ImN1cnZlIjo1fV0sWzEwLDE1LCJcXGFscGhhIiwyLHsiY3VydmUiOjV9XSxbNywxNSwiXFxhbHBoYSIsMCx7ImN1cnZlIjotNX1dLFsxNiwxOCwiXFxtdSIsMCx7ImN1cnZlIjotMSwibGVuZ3RoIjo1MH1dLFsyMSwxOSwiXFxjb25nIiwxLHsiY3VydmUiOjEsImxldmVsIjoxLCJzdHlsZSI6eyJib2R5Ijp7Im5hbWUiOiJub25lIn0sImhlYWQiOnsibmFtZSI6Im5vbmUifX19XSxbMzgsMzksIlxcY29uZyIsMSx7Imxlbmd0aCI6NzAsInN0eWxlIjp7ImJvZHkiOnsibmFtZSI6Im5vbmUifSwiaGVhZCI6eyJuYW1lIjoibm9uZSJ9fX1dLFsyMiwyNSwiXFxwaSIsMCx7ImN1cnZlIjotNCwibGVuZ3RoIjo0MH1dLFszNCwxMCwiXFxyaG8iLDEseyJjdXJ2ZSI6LTEsImxlbmd0aCI6NTB9XSxbNDMsMjIsIlxcUGhpXnstMX0xIiwyLHsibGVuZ3RoIjo1MH1dLFsyNSw0NCwiMVxcUHNpIiwyLHsibGVuZ3RoIjo1MH1dLFszNiw0NiwiXFxjb25nIiwxLHsibGVuZ3RoIjo3MCwic3R5bGUiOnsiYm9keSI6eyJuYW1lIjoibm9uZSJ9LCJoZWFkIjp7Im5hbWUiOiJub25lIn19fV0sWzcsMzAsIlxcbGFtYmRhIiwxLHsiY3VydmUiOi0xLCJsZW5ndGgiOjUwfV0sWzM3LDQ1LCJcXGNvbmciLDEseyJsZW5ndGgiOjcwLCJzdHlsZSI6eyJib2R5Ijp7Im5hbWUiOiJub25lIn0sImhlYWQiOnsibmFtZSI6Im5vbmUifX19XV0=
+
+%%% Invalid diagrams %%%
+
+% Incorrect start.
+begin{tikzcd}
+	A & B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}
+
+% Incorrect end.
+\begin{tikzcd}
+	A & B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd
+
+% Extra content after end.
+
+\begin{tikzcd}
+	A & B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd} :)
+
+% No target 1.
+\begin{tikzcd}
+	A & B
+	\arrow[from=1-1]
+\end{tikzcd}
+
+% No target 2.
+\begin{tikzcd}
+	A \ar[] & B
+\end{tikzcd}
+
+% Same source and target.
+\begin{tikzcd}
+	A & B
+	\arrow[from=1-1, to=1-1]
+\end{tikzcd}
+
+% Invalid source/target.
+\begin{tikzcd}
+	A & B
+	\arrow[from=A, to=B]
+\end{tikzcd}
+
+% Missing source/target.
+\begin{tikzcd}
+	A & B
+	\arrow[from=, to=]
+\end{tikzcd}
+
+% Missing comma.
+\begin{tikzcd}
+	A & B
+	\arrow[from=1-1 to=1-2]
+\end{tikzcd}
+
+% Double comma.
+\begin{tikzcd}
+	A & B
+	\arrow[from=1-1, , to=1-2]
+\end{tikzcd}
+
+% Unexpected end of arrow options.
+\begin{tikzcd}
+	A & B
+	\arrow[from=1-1,
+
+% Loop
+\begin{tikzcd}
+	A \arrow[loop, distance=2em, in=55, out=125]
+\end{tikzcd}
+
+% Zero length arrow.
+\begin{tikzcd}
+	A & B
+	\arrow[shorten <=10pt, shorten >=10pt, from=1-1, to=1-2]
+\end{tikzcd}
+
+% No ampersand replacement.
+\begin{tikzcd}[ampersand replacement=]
+	A & B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}
+
+% No &.
+\begin{tikzcd}
+	A B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}
+
+% Multiple node errors.
+\begin{tikzcd}
+	A B C
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}
+
+% No separation.
+\begin{tikzcd}[sep=]
+	A & B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}
+
+% No name.
+\begin{tikzcd}
+	A & B
+	\arrow["f"{name=}, from=1-1, to=1-2]
+\end{tikzcd}
+
+% Missing colour.
+\begin{tikzcd}
+	A & B
+	\arrow[color=, from=1-1, to=1-2]
+\end{tikzcd}
+
+% Invalid node colour 1.
+\begin{tikzcd}
+	\textcolor{A} & B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}
+
+% Invalid node colour 2.
+\begin{tikzcd}
+	\textcolor{rgb,256:red,0;green,0;blue,0}{A} & B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}
+
+% Colour without node.
+\begin{tikzcd}
+	\textcolor{rgb,255:red,214;green,92;blue,92} & B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}
+
+% Invalid arrow colour.
+\begin{tikzcd}
+	A & B
+	\arrow[color={rgb,256:red,0;green,0;blue,0}, from=1-1, to=1-2]
+\end{tikzcd}
+
+% Invalid level 1.
+\begin{tikzcd}
+	A & B
+	\arrow[Rightarrow, scaling nfold=5, from=1-1, to=1-2]
+\end{tikzcd}
+
+% Invalid level 2.
+\begin{tikzcd}
+	A & B
+	\arrow[Rightarrow, scaling nfold=unknown, from=1-1, to=1-2]
+\end{tikzcd}
+
+% Unknown arrow option.
+\begin{tikzcd}
+	A & B
+	\arrow[unknown, from=1-1, to=1-2]
+\end{tikzcd}
+
+% Unknown diagram option.
+\begin{tikzcd}[unknown]
+	A & B
+	\arrow[from=1-1, to=1-2]
+\end{tikzcd}
+
+% Unknown label option.
+\begin{tikzcd}
+	A & B
+	\arrow["f"{unknown}, from=1-1, to=1-2]
+\end{tikzcd}
+
+% Multiple errors.
+\begin{tikzcd}
+	A & B
+	\arrow[curve={height=X}, from=1-1, to=1-2]
+	\arrow[curve={height=X}, from=1-1, to=1-2]
+	\arrow[curve={height=X}, from=1-1, to=1-2]
+\end{tikzcd}


### PR DESCRIPTION
This pull request implements a parser for tikz-cd code.

<img width="591" alt="image" src="https://github.com/varkor/quiver/assets/3943692/c67c1a75-258a-474a-b98c-db9382f978e7">

The intention is that diagrams exported from **quiver**, or simple tikz-cd diagrams written by hand, can be imported into **quiver** and edited. This process is not always perfect, e.g. length calculation (e.g. for shortened arrows) is heuristic-based, but it generally works pretty well.

A particularly useful consequence of a parser is that one can import diagrams after doing search-and-replace (since this feature is not available directly in **quiver**: #81).

There are likely to be edge cases I have not considered, or are not properly handled, but this serves as a base that can be built upon.

Fixes #40.