### PR TITLE
refactor: use esm

### DIFF
--- a/src/arrow.mjs
+++ b/src/arrow.mjs
@@ -1,11 +1,13 @@
-"use strict";
+import { Arc, Bezier, Curve, CurvePoint, EPSILON, RoundedRectangle } from "./curve.mjs";
+import { DOM } from "./dom.mjs";
+import { Dimensions, Enum, Path, Point, rad_to_deg } from "./ds.mjs";
 
 /// `Array.prototype.includes` but for multiple needles.
 function includes_any(array, ...values) {
     return !values.every((element) => !array.includes(element));
 }
 
-class QuiverSVG {
+export class QuiverSVG {
     constructor() {
         // Create a top-level SVG. This will include all the edges and labels as children.
         // Note that we need to explicitly set the namespace attribute so that the SVG can be
@@ -16,7 +18,7 @@ class QuiverSVG {
 
 // Note that we sometimes use fractional pixel values to align drawings optimally with the pixel
 // grid.
-const CONSTANTS = {
+export const CONSTANTS = {
     /// The space (in pixels) between each line in an n-cell. This space is the distance from the
     /// "outside" of each line: if the lines are thicker, the whitespace between them will be
     /// unaltered, so they will be pushed farther apart.
@@ -123,7 +125,7 @@ const CONSTANTS = {
     ),
 };
 
-class ArrowStyle {
+export class ArrowStyle {
     constructor() {
         // The "n" in "n-cell". Must be a positive integer.
         this.level = 1;
@@ -150,7 +152,7 @@ class ArrowStyle {
     }
 }
 
-class Label {
+export class Label {
     constructor() {
         this.size = Dimensions.zero();
         this.alignment = CONSTANTS.LABEL_ALIGNMENT.CENTRE;
@@ -158,7 +160,7 @@ class Label {
     }
 }
 
-class Shape {
+export class Shape {
     /// Return a point representing the origin of the shape.
     point() {
         return new Shape.Endpoint(this.origin);
@@ -183,7 +185,7 @@ Shape.Endpoint = class extends Shape {
     }
 }
 
-class Arrow {
+export class Arrow {
     constructor(source, target, style = new ArrowStyle(), label = null) {
         this.source = source;
         this.target = target;

--- a/src/curve.mjs
+++ b/src/curve.mjs
@@ -1,8 +1,8 @@
-"use strict";
+import { Point, mod } from "./ds.mjs";
 
 /// A very small value we use to determine fuzzy equality of points. Floating-point arithmetic is
 /// imprecise, so we have to take slight inequalities into account when computing.
-const EPSILON = 10 ** -6;
+export const EPSILON = 10 ** -6;
 const INV_EPSILON = 1 / EPSILON;
 
 // Round a number to the nearest `EPSILON` to avoid floating point precision issues.
@@ -10,7 +10,7 @@ function round_to_epsilon(x) {
     return Math.round(x * INV_EPSILON) / INV_EPSILON;
 }
 
-class Curve {
+export class Curve {
     /// Returns whether a point lies inside a polygon. This does so by calculating the winding
     /// number for the polygon with respect to the point. If the winding number is nonzero, then
     /// the point lies inside the polygon.
@@ -63,7 +63,7 @@ class Curve {
 }
 
 /// A flat symmetric quadratic Bézier curve.
-class Bezier extends Curve {
+export class Bezier extends Curve {
     constructor(origin, w, h, angle) {
         super();
         this.origin = origin;
@@ -295,7 +295,7 @@ class Bezier extends Curve {
 
 /// A point on a quadratic Bézier curve or arc, which also records the parameter `t` and the tangent
 /// `angle` of the curve at the point.
-class CurvePoint extends Point {
+export class CurvePoint extends Point {
     constructor(point, t, angle) {
         super(point.x, point.y);
         this.t = t;
@@ -326,7 +326,7 @@ class NormalisedBezier {
     }
 }
 
-class RoundedRectangle {
+export class RoundedRectangle {
     /// Create a rounded rectangle with centre `(cx, cy)`, width `w`, height `h` and border radius
     /// `r`.
     constructor(centre, size, radius) {
@@ -405,7 +405,7 @@ class RoundedRectangle {
 
 /// A very simple class for computing the value of a cubic Bézier at a point, using for replicating
 /// CSS transition timing functions in JavaScript.
-class CubicBezier {
+export class CubicBezier {
     constructor(p0, p1, p2, p3) {
         this.p0 = p0;
         this.p1 = p1;
@@ -424,7 +424,7 @@ class CubicBezier {
 }
 
 /// A circular arc.
-class Arc extends Curve {
+export class Arc extends Curve {
     constructor(origin, chord, major, radius, angle) {
         super();
         this.origin = origin;

--- a/src/dom.mjs
+++ b/src/dom.mjs
@@ -1,12 +1,12 @@
-"use strict";
+import { clamp } from "./ds.mjs";
 
 /// A helper method to trigger later in the event queue.
-function delay(f, duration = 0) {
+export function delay(f, duration = 0) {
     setTimeout(f, duration);
 }
 
 /// A helper method to cancel the default behaviour of an event.
-function cancel(event) {
+export function cancel(event) {
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();
@@ -17,7 +17,7 @@ function cancel(event) {
 // events instead.
 // This should behave acceptably, because we don't access many pointer-specific properties in the
 // pointer events, and for those that we do, `undefined` will behave as expected.
-function pointer_event(name) {
+export function pointer_event(name) {
     if (`onpointer${name}` in document.documentElement) {
         return `pointer${name}`;
     } else {
@@ -26,7 +26,7 @@ function pointer_event(name) {
 }
 
 /// A helper object for dealing with the DOM.
-const DOM = {};
+export const DOM = {};
 
 /// A class for conveniently dealing with elements. It's primarily useful in giving us a way to
 /// create an element and immediately set properties and styles, in a single statement.

--- a/src/ds.mjs
+++ b/src/ds.mjs
@@ -1,7 +1,5 @@
-"use strict";
-
 /// An enumeration type.
-class Enum {
+export class Enum {
     constructor(name, ...variants) {
         for (const variant of variants) {
             this[variant] = Symbol(`${name}::${variant}`);
@@ -10,7 +8,7 @@ class Enum {
 }
 
 /// A quintessential 2D (x, y) point.
-class Point {
+export class Point {
     constructor(x, y) {
         [this.x, this.y] = [x, y];
     }
@@ -109,14 +107,14 @@ class Point {
 
 /// Equivalent to `Point`, but used semantically to refer to a position (in cell indices)
 /// on the canvas.
-class Position extends Point {}
+export class Position extends Point {}
 
 /// Equivalent to `Point`, but used semantically to refer to a position (in pixels) on the canvas.
-class Offset extends Point {}
+export class Offset extends Point {}
 
 /// An (width, height) pair. This is essentially functionally equivalent to `Point`,
 /// but has different semantic intent.
-const Dimensions = class extends Position {
+export const Dimensions = class extends Position {
     get width() {
         return this.x;
     }
@@ -127,17 +125,17 @@ const Dimensions = class extends Position {
 };
 
 /// Convert radians to degrees.
-function rad_to_deg(rad) {
+export function rad_to_deg(rad) {
     return rad * 180 / Math.PI;
 }
 
 /// Convert degrees to radians.
-function deg_to_rad(deg) {
+export function deg_to_rad(deg) {
     return deg * Math.PI / 180;
 }
 
 /// A class for conveniently generating and manipulating SVG paths.
-class Path {
+export class Path {
     constructor() {
         this.commands = [];
     }
@@ -193,11 +191,11 @@ class Path {
     }
 }
 
-function clamp(min, x, max) {
+export function clamp(min, x, max) {
     return Math.max(min, Math.min(x, max));
 }
 
-function arrays_equal(array1, array2) {
+export function arrays_equal(array1, array2) {
     if (array1.length !== array2.length) {
         return false;
     }
@@ -211,18 +209,18 @@ function arrays_equal(array1, array2) {
     return true;
 }
 
-function mod(x, y) {
+export function mod(x, y) {
     return (x % y + y) % y;
 }
 
 // A type with custom JSON encoding.
-class Encodable {
+export class Encodable {
     eq(/* other */) {
         console.error("`eq` must be implemented for each subclass.");
     }
 }
 
-class Colour extends Encodable {
+export class Colour extends Encodable {
     constructor(h, s, l, a = 1, name = Colour.colour_name([h, s, l, a])) {
         super();
         [this.h, this.s, this.l, this.a] = [h, s, l, a];
@@ -391,7 +389,7 @@ class Colour extends Encodable {
 /// Returns a `Map` containing the current URL's query parameters, as well as parameters stored in
 /// the fragment identifier. If a parameter is found in both the query string and the fragment
 /// identifier, the query string parameter is prioritised.
-function url_parameters() {
+export function url_parameters() {
     let data = [];
     const fragment_string = window.location.hash.replace(/^#/, "");
     if (fragment_string !== "") {

--- a/src/index.html
+++ b/src/index.html
@@ -35,13 +35,13 @@
     <link rel="preload" href="icons/zoom-out.svg" as="image">
     <!-- Style sheets and scripts -->
     <link rel="stylesheet" type="text/css" media="screen" href="main.css">
-    <script type="text/javascript" src="ds.js"></script>
-    <script type="text/javascript" src="dom.js"></script>
-    <script type="text/javascript" src="quiver.js"></script>
-    <script type="text/javascript" src="curve.js"></script>
-    <script type="text/javascript" src="arrow.js"></script>
-    <script type="text/javascript" src="parser.js"></script>
-    <script type="text/javascript" src="ui.js"></script>
+    <script type="module" src="ds.mjs"></script>
+    <script type="module" src="dom.mjs"></script>
+    <script type="module" src="quiver.mjs"></script>
+    <script type="module" src="curve.mjs"></script>
+    <script type="module" src="arrow.mjs"></script>
+    <script type="module" src="parser.mjs"></script>
+    <script type="module" src="ui.mjs"></script>
     <!-- Web app manifest -->
     <link rel="manifest" href="manifest.json">
     <!-- Service worker -->
@@ -57,7 +57,10 @@
         <img src="quiver.svg" class="logo">
     </a>
     <noscript>JavaScript must be enabled to use quiver.</noscript>
-    <script>
+    <script type="module">
+        import { url_parameters } from "./ds.mjs";
+        import { cancel, DOM, pointer_event } from "./dom.mjs";
+
         // If we are loading a diagram, display a loading screen to prevent a flash of empty canvas.
         // We do this in a `<script>` tag here to make sure that it loads immediately.
         const query_data = url_parameters();

--- a/src/parser.mjs
+++ b/src/parser.mjs
@@ -1,3 +1,9 @@
+import { CONSTANTS } from "./arrow.mjs";
+import { DOM, delay } from "./dom.mjs";
+import { Colour, Position, clamp, mod } from "./ds.mjs";
+import { QuiverExport } from "./quiver.mjs";
+import { Edge, Vertex } from "./ui.mjs";
+
 /// This is a simple recursive descent parser for tikz-cd diagrams. The intention is to be able to
 /// parse those diagrams exported by quiver, in addition to a handful of other tikz-cd features that
 /// are commonly used in hand-written diagrams. Most of the implementation is dealing with errors
@@ -6,7 +12,7 @@
 /// diagram (though this is certainly something we would like to aim for): some of the techniques we
 /// use are heuristic-based (e.g. calculating lengths), and guaranteeing a perfect round-trip is not
 /// feasible.
-class Parser {
+export class Parser {
     constructor(ui, code) {
         this.ui = ui;
         // `souce` is not changed.

--- a/src/quiver.mjs
+++ b/src/quiver.mjs
@@ -1,7 +1,11 @@
-"use strict";
+import { delay } from "./dom.mjs";
+import { Colour, Encodable, Point, Position, mod } from "./ds.mjs";
+import { CONSTANTS } from "./arrow.mjs";
+import { Parser } from "./parser.mjs";
+import { Edge, Vertex } from "./ui.mjs";
 
 /// A directed n-pseudograph, in which (k + 1)-cells can connect k-cells.
-class Quiver {
+export class Quiver {
     constructor() {
         /// An array of array of cells. `cells[k]` is the array of k-cells.
         /// `cells[0]` is therefore the array of objects, etc.
@@ -230,13 +234,13 @@ class Quiver {
 }
 
 /// Various methods of exporting a quiver.
-class QuiverExport {
+export class QuiverExport {
     /// A method to export a quiver as a string.
     export() {}
 }
 
 /// Various methods of exporting and importing a quiver.
-class QuiverImportExport extends QuiverExport {
+export class QuiverImportExport extends QuiverExport {
     /// A method to import a quiver as a string. `import(export(quiver))` should be the
     /// identity function. Currently `import` takes a `UI` into which to import directly.
     import() {}

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -1,4 +1,9 @@
-"use strict";
+import { Arrow, ArrowStyle, CONSTANTS, Label, Shape } from "./arrow.mjs";
+import { CubicBezier } from "./curve.mjs";
+import { cancel, DOM, delay, pointer_event } from "./dom.mjs";
+import { Colour, Dimensions, Enum, Offset, Point, Position, clamp, deg_to_rad, mod, rad_to_deg, url_parameters } from "./ds.mjs";
+import { Parser } from "./parser.mjs";
+import { Quiver, QuiverImportExport } from "./quiver.mjs";
 
 /// Various parameters.
 Object.assign(CONSTANTS, {
@@ -7295,7 +7300,7 @@ class Cell {
 Cell.NEXT_ID = 0;
 
 /// 0-cells, or vertices. This is primarily specialised in its set up of HTML elements.
-class Vertex extends Cell {
+export class Vertex extends Cell {
     constructor(ui, label, position, label_colour = Colour.black()) {
         super(ui.quiver, 0, label, label_colour);
 
@@ -7421,7 +7426,7 @@ class Vertex extends Cell {
 }
 
 /// k-cells (for k > 0), or edges. This is primarily specialised in its set up of HTML elements.
-class Edge extends Cell {
+export class Edge extends Cell {
     constructor(ui, label, source, target, options, label_colour) {
         super(ui.quiver, Math.max(source.level, target.level) + 1, label, label_colour);
 


### PR DESCRIPTION
refactors dependencies to use ESM internally, allows tracing dependencies, and allows contributors to not hold a mental model of the entire program.

I'm an interested contributor to some open issues, but it's quite hard for me to navigate the codebase without being able to glance at the dependency tree. This could possibly allow for future TypeScript/etc.. usage.

I also noticed a few bugs and other typos while writing this (to find the unresolved imports, I used type-checking on the JS files, which showed a few possible errors).

There are also three circular dependencies between Parser, Quiver, and UI, which should be refactored later. However, I wanted to keep this PR specifically for switching to ESM.

Also note that ESM is strict by default, so I have removed those statements.