### PR TITLE
docs: fix typos

### DIFF
--- a/src/arrow.mjs
+++ b/src/arrow.mjs
@@ -1382,7 +1382,7 @@ export class Arrow {
         let i = 0;
         const angle = curve.angle;
         while (true) {
-            // We will try offseting at distance `label_offset` pixels next.
+            // We will try offsetting at distance `label_offset` pixels next.
             label_offset = (offset_min + offset_max) / 2;
             const rect_centre = centre
                 .rotate(angle)

--- a/src/parser.mjs
+++ b/src/parser.mjs
@@ -15,7 +15,7 @@ import { Edge, Vertex } from "./ui.mjs";
 export class Parser {
     constructor(ui, code) {
         this.ui = ui;
-        // `souce` is not changed.
+        // `source` is not changed.
         this.source = code;
         // `code` is changed as the parse proceeds: it is the remaining source to parse.
         this.code = code;
@@ -35,7 +35,7 @@ export class Parser {
         return this.source.length - this.code.length;
     }
 
-    /// Returns a range starting from the specified position, to the currrent position.
+    /// Returns a range starting from the specified position, to the current position.
     range_from(start) {
         return Parser.Range.from_to(start, this.position);
     }

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -621,7 +621,7 @@ class UI {
         // The default (minimum) size of each column and row, if a width or height has not been
         // specified.
         this.default_cell_size = 128;
-        // The constraints on the width and height of each cell: we use the maximum constaint for
+        // The constraints on the width and height of each cell: we use the maximum constraint for
         // final width/height. We store these separately from `cell_width` and `cell_height` to
         // avoid recomputing the sizes every time, as we access them frequently.
         this.cell_width_constraints = new Map();
@@ -3136,7 +3136,7 @@ class UI {
         // the brackets at least match.
         const newcommand = /^\\((?:re)?newcommand|DeclareMathOperator)(\*?)\{?\\([a-zA-Z]+)\}?(?:\[(\d)\])?\{(.*)\}$/;
         // It's not clear exactly what the rules for colour names is, so we accept a sensible
-        // subset. We don't accept `cymk` for now. We don't validate values in the regex.
+        // subset. We don't accept `cmyk` for now. We don't validate values in the regex.
         const definecolor = /^\\definecolor\{([a-zA-Z0-9\-]+)\}\{(rgb|RGB|gray|HTML)\}\{((?:\d+(?:\.\d+)?)(?:,(?:\d+(?:\.\d+)?))*|[a-fA-F\d]{6})\}$/;
 
         const macros = new Map();
@@ -4178,7 +4178,7 @@ class Panel {
             recording = false;
         };
 
-        // Trigger an efect that changes an edge style, optionally recording the change in the
+        // Trigger an effect that changes an edge style, optionally recording the change in the
         // history.
         const effect_edge_style_change = (record, modify) => {
             if (record) {
@@ -5776,7 +5776,7 @@ class Panel {
                         thumbs[1].set_value(value !== null ? 100 - value.target : 100);
                         break;
                     case "{colour}":
-                        // This case is analagous to `"{label_colour}"` above.
+                        // This case is analogous to `"{label_colour}"` above.
                         // Default to black.
                         this.colour = value || Colour.black();
                         // If we're currently picking a colour, then changing the selection should


### PR DESCRIPTION
While writing #250, I noticed some typos. This runs [`typos`](https://github.com/crate-ci/typos/) just to cover all of them.