### PR TITLE
Export to Typst/Fletcher diagram

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ src/Workbox/workbox-%:
 # Build service worker.
 service-worker: service-worker/build.js
 	cd $(dir $<)
-	. $$NVM_DIR/nvm.sh
+	if [ ! -z "$$NVM_DIR" ]; then . $$NVM_DIR/nvm.sh; fi
 	nvm use 20 && npm install && node build.js
 
 # Generate icons required by the webapp manifest. Requires ImageMagick.

--- a/src/arrow.mjs
+++ b/src/arrow.mjs
@@ -339,7 +339,8 @@ export class Arrow {
         const elements = parent.query_selector_all(selector);
         switch (elements.length) {
             case 0:
-                const [prefix, ...classes] = selector.split(".");
+                // Strip CSS selectors before parsing name, ID, and classes.
+                const [prefix, ...classes] = selector.replace(/^.+>\s+/, "").split(".");
                 const [name, id = null] = prefix.split("#");
                 const extra_attrs = {};
                 if (id !== null) {
@@ -553,7 +554,9 @@ export class Arrow {
 
         // Create a clipping mask for the edge. We use this to cut out the gaps in an n-cell,
         // and also to cut out space for the label when the alignment is `CENTRE`.
-        const defs = this.requisition_element(this.svg, "defs");
+        // Exclude defs that might be in the rendered typst svg.
+        const defs
+            = this.requisition_element(this.svg, "svg:not(.typst-doc) > defs.clipping-masks");
         const clipping_mask = this.requisition_element(
             defs,
             `mask#arrow${this.id}-clipping-mask`,

--- a/src/dom.mjs
+++ b/src/dom.mjs
@@ -164,6 +164,15 @@ DOM.Element = class {
     contains(other) {
         return this.element.contains(other.element);
     }
+
+    select_contents() {
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        const range = document.createRange();
+        range.selectNodeContents(this.element);
+        selection.addRange(range);
+        return this;
+    }
 };
 
 DOM.Div = class extends DOM.Element {

--- a/src/main.css
+++ b/src/main.css
@@ -488,9 +488,8 @@ being. */
     left: 50%;
     bottom: 0;
     transform: translateX(-50%);
-    width: 808px;
     height: 46px;
-    padding: 8px;
+    padding: 8px 12px;
     /* Display above the import/export pane. */
     z-index: 101;
 
@@ -927,7 +926,7 @@ div.slider {
     border-color: var(--ui-blue);
 }
 
-.panel button, .pane button, .port button {
+.panel button, .pane button, .port button, .panel select {
     position: relative;
     display: block;
     width: 100%; height: 30px;
@@ -940,28 +939,27 @@ div.slider {
 
     font: inherit;
     color: var(--ui-white);
+    text-align: center;
+}
+
+.global select {
+    display: inline-block;
+    width: auto;
+    margin: 0;
 }
 
 .global button {
     display: inline-block;
-    width: 112px;
-    margin: 0;
+    width: 72px;
+    margin: 0 2px;
 }
 
 .global button.short {
     width: 56px;
 }
 
-.global button + label {
-    margin-left: 4px;
-}
-
-.global label + button {
-    margin-right: 4px;
-}
-
-.global button:last-of-type {
-    margin-left: 4px;
+.global button + label, .global select + label {
+    margin-left: 12px;
 }
 
 .panel button:hover:not(:disabled):not(:active),
@@ -1103,7 +1101,7 @@ user has already pressed semicolon, placing us in command mode. */
 
 .indicator-container {
     display: inline-block;
-    margin-left: 24px;
+    margin-left: 12px;
 }
 
 .panel .success-indicator {
@@ -1550,6 +1548,10 @@ button.flash {
     color: var(--ui-white);
 }
 
+.port .tip > code {
+    cursor: text;
+}
+
 .port .tip .update {
     padding: 0pt 4pt;
     padding-bottom: 1pt;
@@ -1788,6 +1790,10 @@ label input[type="checkbox"]:checked::before {
     font-size: 1em;
 }
 
+.typst-error {
+  color: var(--ui-error);
+}
+
 /* Embedded view */
 
 .ui.embedded .panel,
@@ -1819,3 +1825,25 @@ label input[type="checkbox"]:checked::before {
 .ui.embedded #welcome-pane {
     display: none;
 }
+
+/* Some interface elements are only relevant to certain renderers. */
+body:has(select[name="renderer"] > option[value="typst"]:checked) .katex-only,
+body:has(select[name="renderer"] > option[value="katex"]:checked) .typst-only {
+    display: none;
+}
+
+/* Animation for loading a slow renderer. */
+
+.breathe {
+    animation: breathe .5s ease-in-out infinite alternate;
+}
+
+@keyframes breathe {
+    from {
+        color: hsl(0, 0%, 0%);
+    }
+    to {
+        color: hsl(0, 0%, 60%);
+    }
+}
+


### PR DESCRIPTION
I've implemented initial support to export to Typst diagrams. Incompatibilities are reported through the incompatibilities metadata object (that is: shortened arrows and k-cells for k > 1)

This still needs some UI adjustments to show the incompatibilities and instructions just like with latex.

I marked this as Draft because I feel like this feature cannot be fully used as-is since I haven't implemented in-browser rendering of the formulas. Looking into how to do that with `typst.ts`.

Feel free to leave comments and to try this out. Diagrams should be readily useable with
```typ
#import "@preview/fletcher:0.5.5" as fletcher: diagram, node, edge
```
at a document's start.

For those wanting to try it, I've got a version hosted [here](https://quiver.theophile.me/)