### PR TITLE
Add option to produce standalone LaTeX documents

### DIFF
--- a/src/quiver.mjs
+++ b/src/quiver.mjs
@@ -615,11 +615,11 @@ QuiverImportExport.tikz_cd = new class extends QuiverImportExport {
                     output.split("\n").map(line => `\t${line}`).join("\n")
                 }\n` : ""
             }\\end{tikzcd}`;
-            if (settings.get("export.centre_diagram")) {
+            if (settings.get("export.centre_diagram") && !settings.get("export.standalone")) {
                 tikzcd = `\\[${tikzcd}\\]`;
             }
             if (settings.get("export.standalone")) {
-                tikzcd = `\\documentclass[crop,tikz]{standalone}\n\\usepackage{quiver}\n\\begin{document}\n${tikzcd}\n\\end{document}`
+                tikzcd = `\\documentclass[tikz]{standalone}\n\\usepackage{quiver}\n\\begin{document}\n${tikzcd}\n\\end{document}`
             }
             // URL.
             return `% ${

--- a/src/quiver.mjs
+++ b/src/quiver.mjs
@@ -618,6 +618,9 @@ QuiverImportExport.tikz_cd = new class extends QuiverImportExport {
             if (settings.get("export.centre_diagram")) {
                 tikzcd = `\\[${tikzcd}\\]`;
             }
+            if (settings.get("export.standalone")) {
+                tikzcd = `\\documentclass[crop,tikz]{standalone}\n\\usepackage{quiver}\n\\begin{document}\n${tikzcd}\n\\end{document}`
+            }
             // URL.
             return `% ${
                 QuiverImportExport.base64.export(quiver, settings, options, definitions).data

--- a/src/quiver.mjs
+++ b/src/quiver.mjs
@@ -619,7 +619,7 @@ QuiverImportExport.tikz_cd = new class extends QuiverImportExport {
                 tikzcd = `\\[${tikzcd}\\]`;
             }
             if (settings.get("export.standalone")) {
-                tikzcd = `\\documentclass[tikz]{standalone}\n\\usepackage{quiver}\n\\begin{document}\n${tikzcd}\n\\end{document}`
+                tikzcd = `\\documentclass[tikz]{standalone}\n\\usepackage{quiver}\n\\begin{document}\n${tikzcd}\n\\end{document}`;
             }
             // URL.
             return `% ${

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -1003,6 +1003,7 @@ class UI {
                 ["Toggle diagram centring", (td) => Shortcuts.element(td, [{ key: "C" }])],
                 ["Toggle ampersand replacement", (td) => Shortcuts.element(td, [{ key: "A" }])],
                 ["Toggle cramped spacing", (td) => Shortcuts.element(td, [{ key: "R" }])],
+                ["Toggle standalone", (td) => Shortcuts.element(td, [{ key: "T" }])],
                 ["Toggle fixed size", (td) => Shortcuts.element(td, [{ key: "F" }])],
             ])));
 
@@ -4874,16 +4875,16 @@ class Panel {
                             .add("Centre diagram")
                         )
                         .add(new DOM.Element("label")
-                            .add(standalone_checkbox)
-                            .add("Standalone")
-                        )
-                        .add(new DOM.Element("label")
                             .add(ampersand_replacement)
                             .add("Ampersand replacement")
                         )
                         .add(new DOM.Element("label")
                             .add(cramped)
                             .add("Cramped")
+                        )
+                        .add(new DOM.Element("label")
+                            .add(standalone_checkbox)
+                            .add("Standalone")
                         )
                         .add(new DOM.Div({ class: "linked-sliders" })
                             .add(sep_sliders.column.label)

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -3887,6 +3887,8 @@ class Settings {
             "export.ampersand_replacement": false,
             // Whether to export diagrams with the `cramped` option.
             "export.cramped": false,
+            // Whether to wrap the `tikz-cd` output in a standalone LaTeX document.
+            "export.standalone": false,
             // Whether to use a fixed size for the embedded `<iframe>`, or compute the size based on
             // the diagram.
             "export.embed.fixed_size": false,
@@ -4862,10 +4864,18 @@ class Panel {
                         type: "checkbox",
                         "data-setting": "export.cramped",
                     });
+                    const standalone_checkbox = new DOM.Element("input", {
+                        type: "checkbox",
+                        "data-setting": "export.standalone",
+                    });
                     latex_options = new DOM.Div({ class: "options latex hidden" })
                         .add(new DOM.Element("label")
                             .add(centre_checkbox_tikzcd)
                             .add("Centre diagram")
+                        )
+                        .add(new DOM.Element("label")
+                            .add(standalone_checkbox)
+                            .add("Standalone")
                         )
                         .add(new DOM.Element("label")
                             .add(ampersand_replacement)
@@ -4908,6 +4918,7 @@ class Panel {
                         [centre_checkbox_typst, "fletcher", "c"],
                         [ampersand_replacement, "tikz-cd", "a"],
                         [cramped, "tikz-cd", "r"],
+                        [standalone_checkbox, "tikz-cd", "s"],
                         [fixed_size_checkbox, "html", "f"],
                     ];
                     const shortcuts = [];

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -1003,7 +1003,7 @@ class UI {
                 ["Toggle diagram centring", (td) => Shortcuts.element(td, [{ key: "C" }])],
                 ["Toggle ampersand replacement", (td) => Shortcuts.element(td, [{ key: "A" }])],
                 ["Toggle cramped spacing", (td) => Shortcuts.element(td, [{ key: "R" }])],
-                ["Toggle standalone", (td) => Shortcuts.element(td, [{ key: "T" }])],
+                ["Toggle standalone", (td) => Shortcuts.element(td, [{ key: "S" }])],
                 ["Toggle fixed size", (td) => Shortcuts.element(td, [{ key: "F" }])],
             ])));
 


### PR DESCRIPTION
This PR adds a checkbox for the LaTeX export that produces a standalone LaTeX document using the `standalone` document class.