### PR TITLE
Fixes 'between' key causes many warning messages

### DIFF
--- a/package/quiver.sty
+++ b/package/quiver.sty
@@ -34,10 +34,25 @@
         \def\pv##1{\pgfkeysvalueof{/tikz/quiver/##1}}},
     quiver/.cd,pos/.initial=0.35,height/.initial=0}
 
-% A TikZ style for shortening paths without the poor behaviour of `shorten <' and `shorten >'.
-\tikzset{between/.style n args={2}{/tikz/execute at end to={
-    \tikzset{spath/split at keep middle={current}{#1}{#2}}
-}}}
+\makeatletter
+\tikzset{between/.style n args={2}{
+    /tikz/spath/at end path construction={
+        % 1. Get the current soft path and store it in \quiver@temppath
+        \pgfsyssoftpath@getcurrentpath{\pgf@temp}%
+        % Check if the path is empty (equal to \pgfutil@empty)
+        \ifx\pgf@temp\pgfutil@empty
+            % The path is empty (likely a tikz-cd calculation phase); do nothing.
+        \else
+            % The path exists; perform the shortening.
+            \tikzset{
+                spath/save=current,
+                spath/split at keep middle={current}{#1}{#2},
+                spath/restore=current
+            }%
+        \fi
+    }
+}}
+\makeatother
 
 % TikZ arrowhead/tail styles.
 \tikzset{tail reversed/.code={\pgfsetarrowsstart{tikzcd to}}}


### PR DESCRIPTION
I attach an MVE of the bug I fixed
- [example.zip](https://github.com/user-attachments/files/25126345/example.zip)

Note the log:

> Missing character: There is no 0 in font nullfont!
> Missing character: There is no . in font nullfont!
> Missing character: There is no 8 in font nullfont!
> Missing character: There is no ( in font nullfont!
> Missing character: There is no 0 in font nullfont!
> Missing character: There is no . in font nullfont!
> Missing character: There is no 2 in font nullfont!
> Missing character: There is no ) in font nullfont!
> Missing character: There is no / in font nullfont!
> Missing character: There is no ( in font nullfont!
> Missing character: There is no 0 in font nullfont!
> Missing character: There is no . in font nullfont!
> Missing character: There is no 8 in font nullfont!
> Missing character: There is no ) in font nullfont!

This is apparently due to the combination of `between` and `shift`. Honestly I don't understand how spath3 works, but with the help of Gemini I managed to obtain the fix in the PR. It prevents these warnings in my tests.