### PR TITLE
fix round-trip issue

### DIFF
--- a/src/parser.mjs
+++ b/src/parser.mjs
@@ -646,6 +646,22 @@ export class Parser {
     /// Parse the options in the square brackets in `\arrow[...]`.
     parse_edge_option(edge) {
         let start = this.position;
+        // Strip redundant outer brace layers from a tikz-cd arrow label so round-trip export/import
+        // does not accumulate braces (e.g. "{f^{X}}" → "f^{X}").
+        const strip_outer_braces = (s) => {
+            while (s.length >= 2 && s[0] === "{" && s[s.length - 1] === "}") {
+                let depth = 0;
+                let i = 0;
+                for (; i < s.length; i++) {
+                    if (s[i] === "{") depth++;
+                    else if (s[i] === "}") depth--;
+                    if (depth === 0) break;
+                }
+                if (i !== s.length - 1) break;
+                s = s.slice(1, -1);
+            }
+            return s;
+        };
         // We special case adjunctions, pullbacks, and barred arrows, since quiver encodes them in a
         // certain way.
         if (this.eat("\"\\dashv\"{anchor=center")) {
@@ -726,7 +742,7 @@ export class Parser {
         if (this.eat("\"")) {
             const label = this.eat(/[^"]*/);
             this.eat("\"", true);
-            edge.label = label;
+            edge.label = strip_outer_braces(label);
             while (this.eat("'")) {
                 swap_label_alignment();
             }

--- a/src/quiver.mjs
+++ b/src/quiver.mjs
@@ -402,6 +402,9 @@ QuiverImportExport.tikz_cd = new class extends QuiverImportExport {
         // readable. In general, we need to use curly brackets to avoid LaTeX errors. For instance,
         // `[a]` is invalid: we must use `{[a]}` instead.
         const simple_label = /^\\?[a-zA-Z0-9]+$/;
+        // In tikz-cd, the quoted string in \arrow only requires outer braces when it contains
+        // characters that would break parsing: "[", "]", or "\"".
+        const needs_braces = (s) => /[\[\]"]/.test(s);
 
         // Adapt a label to be appropriate for TikZ output, by surrounding it in curly brackets when
         // necessary, and using `\array` for newlines.
@@ -411,7 +414,7 @@ QuiverImportExport.tikz_cd = new class extends QuiverImportExport {
                 // which is permitted to contain newlines.
                 return `\\begin{array}{c} ${label} \\end{array}`;
             }
-            if (!simple_label.test(label)) {
+            if (needs_braces(label)) {
                 return `{${label}}`;
             }
             return label;


### PR DESCRIPTION
**Export (quiver.mjs)**: Added needs_braces(s) — true only when the label contains [, ], or ". format_label now wraps in { } only when needs_braces(label) is true, so labels like f^{X} are no longer wrapped. Left simple_label in place.


**Import (parser.mjs)**: Added strip_outer_braces(s) to remove one level of balanced outer { } in a loop. The parsed arrow label is passed through it before edge.label = ..., so round-trip no longer adds extra braces.