### PR TITLE
Support Custom Macros Workspace via Direct Text Editing

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -171,7 +171,7 @@ kbd {
     white-space: pre;
 }
 
-.tooltip kbd, .pane kbd, .port kbd {
+.tooltip kbd, .pane kbd, .port kbd, .pane textarea {
     padding: 1px 6px;
 
     border-radius: 4px;

--- a/src/main.css
+++ b/src/main.css
@@ -1685,7 +1685,7 @@ label input[type="checkbox"]:checked::before {
     color: var(--ui-black);
 }
 
-.port .code, .port div[contenteditable] {
+.port .code, .port div[contenteditable], .macros-input {
     font: 16px monospace;
     color: var(--ui-white);
 
@@ -1695,7 +1695,7 @@ label input[type="checkbox"]:checked::before {
     -moz-tab-size: 4;
 }
 
-.port div[contenteditable] {
+.port div[contenteditable], .macros-input {
     width: 100%;
     height: 252pt;
     resize: none;

--- a/src/main.css
+++ b/src/main.css
@@ -190,7 +190,7 @@ kbd {
     white-space: pre;
 }
 
-.tooltip kbd, .pane kbd, .port kbd {
+.tooltip kbd, .pane kbd, .port kbd, .pane textarea {
     padding: 1px 6px;
 
     border-radius: 4px;
@@ -671,6 +671,7 @@ label.inline {
 }
 
 .panel input[type="text"],
+.pane input[type="text"],
 .port .options input[type="number"] {
     padding: 2px 4px;
 
@@ -685,16 +686,19 @@ label.inline {
 }
 
 .panel input[type="text"]::placeholder,
+.pane input[type="text"]::placeholder,
 .port .options input[type="number"]::placeholder {
     color: hsla(0, 0%, 100%, 0.4);
 }
 
 .panel input[type="text"]:hover:not(:disabled):not(:focus),
+.pane input[type="text"]:hover:not(:disabled):not(:focus),
 .port .options input[type="number"]:hover:not(:disabled):not(:focus) {
     background: var(--ui-hover);
 }
 
 .panel input[type="text"]:focus,
+.pane input[type="text"]:focus,
 .port .options input[type="number"]:focus {
     background: var(--ui-focus);
     border-color: var(--ui-focus);
@@ -703,6 +707,7 @@ label.inline {
 }
 
 .panel input[type="text"]:focus::placeholder,
+.pane input[type="text"]:focus::placeholder,
 .port .options input[type="number"]:focus::placeholder {
     color: hsla(0, 0%, 0%, 0.4);
 }
@@ -1136,43 +1141,6 @@ user has already pressed semicolon, placing us in command mode. */
 /* When cells are queued, we can press Tab to select them. */
 .ui:not(.command).show-queue .cell kbd.queue.hint::before {
     content: "⇥";
-}
-
-.indicator-container {
-    display: inline-block;
-    margin-left: 12px;
-}
-
-.panel .success-indicator {
-    display: inline-block;
-    vertical-align: middle;
-    margin-left: 8px;
-    width: 18px; height: 18px;
-
-    background: hsl(0, 0%, 36%);
-    border-radius: 100%;
-
-    color: hsl(0, 0%, 16%);
-    text-align: center;
-    line-height: 18px;
-
-    transform: scale(0);
-
-    transition: transform 0.2s;
-}
-
-.panel .success-indicator.unknown,
-.panel .success-indicator.success,
-.panel .success-indicator.failure {
-    transform: scale(1);
-}
-
-.panel .success-indicator.success::before {
-    content: "✓";
-}
-
-.panel .success-indicator.failure::before {
-    content: "✕";
 }
 
 /* The colour picker */
@@ -1733,7 +1701,7 @@ label input[type="checkbox"]:checked::before {
     color: var(--ui-black);
 }
 
-.port .code, .port div[contenteditable] {
+.port .code, .port div[contenteditable], .pane textarea {
     font: 16px monospace;
     color: var(--ui-white);
 
@@ -1743,17 +1711,24 @@ label input[type="checkbox"]:checked::before {
     -moz-tab-size: 4;
 }
 
-.port div[contenteditable] {
+.port div[contenteditable], .pane textarea {
     width: 100%;
-    height: 252pt;
     resize: none;
     padding: 6pt 8pt;
-    overflow-y: auto;
 
     background: hsla(0, 0%, 0%, 0.2);
 
     border: none;
     outline: none;
+}
+
+.port div[contenteditable] {
+    height: 252pt;
+    overflow-y: auto;
+}
+
+.pane textarea {
+    height: 180pt;
 }
 
 /* We pad empty fragments so that we can see their highlight. */

--- a/src/quiver.mjs
+++ b/src/quiver.mjs
@@ -1279,13 +1279,12 @@ QuiverImportExport.base64 = new class extends QuiverImportExport {
             };
         }
 
-        // Encode the macro URL if it's not null.
-        const macro_url_data = options.macro_url !== null
-            ? `&macro_url=${encodeURIComponent(options.macro_url)}` : "";
-
-        // Encode the custom macro text if it's not null and not empty.
-        const macro_text_data = options.macro_text !== null && options.macro_text !== ""
-            ? `&macros=${encodeURIComponent(options.macro_text)}` : "";
+        // Encode exactly one macro source: inline definitions take precedence over URL macros.
+        const macro_data = options.macro_text !== null && options.macro_text !== ""
+            ? `&macros=${encodeURIComponent(options.macro_text)}`
+            : (options.macro_url !== null
+                ? `&macro_url=${encodeURIComponent(options.macro_url)}`
+                : "");
 
         const renderer = settings.get("quiver.renderer");
         return {
@@ -1293,7 +1292,7 @@ QuiverImportExport.base64 = new class extends QuiverImportExport {
             data: `${URL_prefix}#${renderer === CONSTANTS.DEFAULT_RENDERER ? ""
                     : `r=${renderer}&`}q=${
                 this.export_selection(quiver, new Set(quiver.all_cells()))
-            }${macro_url_data}${macro_text_data}`,
+            }${macro_data}`,
             metadata: {},
         };
     }

--- a/src/quiver.mjs
+++ b/src/quiver.mjs
@@ -1280,8 +1280,12 @@ QuiverImportExport.base64 = new class extends QuiverImportExport {
         }
 
         // Encode the macro URL if it's not null.
-        const macro_data = options.macro_url !== null
+        const macro_url_data = options.macro_url !== null
             ? `&macro_url=${encodeURIComponent(options.macro_url)}` : "";
+
+        // Encode the custom macro text if it's not null and not empty.
+        const macro_text_data = options.macro_text !== null && options.macro_text !== ""
+            ? `&macros=${encodeURIComponent(options.macro_text)}` : "";
 
         const renderer = settings.get("quiver.renderer");
         return {
@@ -1289,7 +1293,7 @@ QuiverImportExport.base64 = new class extends QuiverImportExport {
             data: `${URL_prefix}#${renderer === CONSTANTS.DEFAULT_RENDERER ? ""
                     : `r=${renderer}&`}q=${
                 this.export_selection(quiver, new Set(quiver.all_cells()))
-            }${macro_data}`,
+            }${macro_url_data}${macro_text_data}`,
             metadata: {},
         };
     }

--- a/src/quiver.mjs
+++ b/src/quiver.mjs
@@ -1318,9 +1318,14 @@ QuiverImportExport.base64 = new class extends QuiverImportExport {
             };
         }
 
-        // Encode the macro URL if it's not null.
-        const macro_data = options.macro_url !== null
-            ? `&macro_url=${encodeURIComponent(options.macro_url)}` : "";
+        // Encode at most one macro source. It should not be possible for both `macro_url` and
+        // `macro_text` to be non-null: however, if for whatever reason they are both non-null, we
+        // prioritise inline definitions over URL macros.
+        const macro_data = options.macro_text !== null && options.macro_text.trim() !== ""
+            ? `&macros=${encodeURIComponent(options.macro_text)}`
+            : (options.macro_url !== null && options.macro_url.trim() !== ""
+                ? `&macro_url=${encodeURIComponent(options.macro_url)}`
+                : "");
 
         const renderer = settings.get("quiver.renderer");
         return {

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -3010,7 +3010,7 @@ class UI {
     /// actions (primarily keyboard shortcuts) will be disabled.)
     input_is_active() {
         // This may not be the label input, e.g. it may be the macros input.
-        return document.activeElement.matches('input[type="text"], div[contenteditable]')
+        return document.activeElement.matches('input[type="text"], div[contenteditable], textarea')
             && document.activeElement;
     }
 

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -735,6 +735,12 @@ class UI {
         // The macro definitions inserted by the user.
         this.macro_text = null;
 
+        // The macro definitions most recently loaded from `macro_url`.
+        this.macro_url_text = null;
+
+        // A monotonically increasing ID used to ignore stale macro URL fetch results.
+        this.macro_load_version = 0;
+
         // The user settings, which are stored persistently across sessions in `localStorage`.
         this.settings = new Settings();
     }
@@ -1191,8 +1197,23 @@ class UI {
             .add(new DOM.Element("p").add("Use this editor to define custom LaTeX commands and colours."))
             .add(this.macros_input)
             .add(new DOM.Element("button").add("Apply Definitions").listen("click", () => {
-                this.macro_text = this.macros_input.element.textContent;
-                this.load_macros(this.macro_text);
+                const text = this.macros_input.element.textContent;
+                const edited_url_macros = this.macro_url !== null
+                    && this.macro_url_text !== null
+                    && text !== this.macro_url_text;
+
+                if (edited_url_macros || this.macro_url === null) {
+                    // Inline edits take precedence and invalidate URL fetches in flight.
+                    ++this.macro_load_version;
+                    this.macro_text = text;
+                    this.macro_url = null;
+                    this.macro_url_text = null;
+                } else {
+                    // URL macros are unchanged, so keep URL as the canonical source.
+                    this.macro_text = null;
+                }
+
+                this.load_macros(text);
                 this.dismiss_pane();
             }));
         panes.push(macros_pane);
@@ -3483,6 +3504,7 @@ class UI {
         // want to store invalid URLs, so we'll set `this.macro_url` when we succeed in fetching the
         // definitions.
         this.macro_url = null;
+        this.macro_url_text = null;
 
         const macro_input = this.panel.global.query_selector("input");
         url = url.trim();
@@ -3496,6 +3518,7 @@ class UI {
         UI.dismiss_error("macro-load");
 
         if (url !== "") {
+            const load_version = ++this.macro_load_version;
             success_indicator.class_list.add("unknown");
             // CORS is terribly frustrating. We simply want to fetch some text, but are often
             // unable to do so, because CORS is opt-in and most sites have not. To alleviate this
@@ -3508,13 +3531,22 @@ class UI {
                 fetch(`${prefix}${url}`, { credentials: "omit" })
                     .then((response) => response.text())
                     .then((text) => {
+                        if (load_version !== this.macro_load_version) {
+                            return;
+                        }
                         this.load_macros(text);
+                        this.macro_text = null;
                         this.macro_url = url;
+                        this.macro_url_text = text;
+                        this.macros_input.element.textContent = text;
                         success_indicator.class_list.remove("unknown");
                         success_indicator.class_list.add("success");
                         macro_input.element.blur();
                     })
                     .catch(() => {
+                        if (load_version !== this.macro_load_version) {
+                            return;
+                        }
                         if (repeat && !url.startsWith(CORS_PROXY)) {
                             // Attempt to fetch using cors-anywhere.
                             attempt_to_fetch_macros(url, CORS_PROXY, false);
@@ -3531,6 +3563,12 @@ class UI {
             };
             attempt_to_fetch_macros(url);
         } else {
+            // Cancel any in-flight URL fetch and reset macro source state.
+            ++this.macro_load_version;
+            this.macro_text = null;
+            this.macro_url_text = null;
+            this.macros_input.element.textContent = "";
+
             // If the URL is empty, we simply reset all macro and colour definitions (as if the user
             // had never loaded any macros or colours).
             this.macros = new Map();
@@ -5669,7 +5707,9 @@ class Panel {
                         ui.dismiss_pane();
                         ui.panel.dismiss_port_pane(ui);
                         if (is_hidden) {
-                            ui.macros_input.element.value = ui.macro_text || "";
+                            ui.macros_input.element.textContent = ui.macro_text
+                                || ui.macro_url_text
+                                || "";
                             pane.class_list.remove("hidden");
                         }
                     })
@@ -8376,14 +8416,17 @@ document.addEventListener("DOMContentLoaded", () => {
             try {
                 // Decode the diagram.
                 QuiverImportExport.base64.import(ui, query_data.get("q"));
-                // If there is a `macro_url`, load the macros from it.
-                if (query_data.has("macro_url")) {
-                    ui.load_macros_from_url(decodeURIComponent(query_data.get("macro_url")));
-                }
-                // If there are directly embedded macros, load them.
+                // If there are directly embedded macros, prefer them to avoid URL import races.
                 if (query_data.has("macros")) {
+                    ++ui.macro_load_version;
                     ui.macro_text = decodeURIComponent(query_data.get("macros"));
+                    ui.macro_url = null;
+                    ui.macro_url_text = null;
+                    ui.macros_input.element.textContent = ui.macro_text;
                     ui.load_macros(ui.macro_text);
+                // Otherwise, if there is a `macro_url`, load the macros from it.
+                } else if (query_data.has("macro_url")) {
+                    ui.load_macros_from_url(decodeURIComponent(query_data.get("macro_url")));
                 }
                 // Adjust the diagram scale to fit the screen in embedded view.
                 // However, we have to be careful to only do this if the user

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -1146,6 +1146,37 @@ class UI {
                 .add(".")
             );
         panes.push(welcome_pane);
+
+        // Set up the macros pane.
+        this.macros_input = new DOM.Element("textarea", {
+            placeholder: "\\newcommand{\\A}{\\mathbb{A}}\\definecolor{mycolor}{RGB}{205,92,92}",
+            class: "macros-textarea",
+            style: "width: 100%; height: 200px; font-family: monospace; padding: 0.5rem; margin-bottom: 1rem; box-sizing: border-box;",
+        }).listen("wheel", (event) => {
+            event.stopImmediatePropagation();
+        }, { passive: true });
+
+        const macros_pane = new DOM.Div({ id: "macros-pane", class: "pane hidden" })
+            .add(new DOM.Element("h1").add("Custom Macros"))
+            .add(new DOM.Element("p").add("Use this editor to define custom LaTeX commands and colours."))
+            .add(this.macros_input)
+            .add(new DOM.Element("button").add("Apply Definitions").listen("click", () => {
+                this.macro_text = this.macros_input.element.value;
+                this.load_macros(this.macro_text);
+                this.dismiss_pane();
+            }));
+        panes.push(macros_pane);
+
+        // Set up the macros help pop up.
+        const macros_help_pane = new DOM.Div({ id: "macros-help-pane", class: "pane hidden" })
+            .add(new DOM.Element("h1").add("Custom Macros"))
+            .add(new DOM.Element("p").add("This feature allows you to use custom macros in quiver."))
+            .add(new DOM.Element("p").add("Refer to ").add(new DOM.Link("https://github.com/varkor/quiver/blob/master/tutorial.md#importing-macros-and-colours", "the documentation", true)).add(" for more details."))
+            .add(new DOM.Element("button").add("Close").listen("click", () => {
+                this.dismiss_pane();
+            }));
+        panes.push(macros_help_pane);
+
         new DOM.Element("button").add("Get started").listen("click", () => {
             // There are technically other ways to dismiss the welcome pane (e.g. opening the
             // keyboard shortcuts pane without clicking this button). We choose not to set the

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -1148,20 +1148,50 @@ class UI {
         panes.push(welcome_pane);
 
         // Set up the macros pane.
-        this.macros_input = new DOM.Element("textarea", {
-            placeholder: "\\newcommand{\\A}{\\mathbb{A}}\\definecolor{mycolor}{RGB}{205,92,92}",
-            class: "macros-textarea",
-            style: "width: 100%; height: 200px; font-family: monospace; padding: 0.5rem; margin-bottom: 1rem; box-sizing: border-box;",
+        const insert_macro_text = (text) => {
+            const selection = window.getSelection();
+            const range = selection.getRangeAt(0);
+            range.deleteContents();
+            range.insertNode(document.createTextNode(text));
+            selection.collapseToEnd();
+        };
+
+        this.macros_input = new DOM.Div({
+            contenteditable: "true",
+            spellcheck: "false",
+            class: "macros-input",
         }).listen("wheel", (event) => {
             event.stopImmediatePropagation();
-        }, { passive: true });
+        }, { passive: true }).listen("keydown", (event) => {
+            if (event.key === "Enter") {
+                event.preventDefault();
+                event.stopPropagation();
+
+                const text = this.macros_input.element.textContent;
+                const selection = window.getSelection();
+                if (selection.rangeCount > 0) {
+                    const range = selection.getRangeAt(0);
+                    const total_range = range.cloneRange();
+                    total_range.selectNodeContents(this.macros_input.element);
+                    total_range.setEnd(range.startContainer, range.startOffset);
+                    const caret = total_range.toString().length;
+                    if (caret === text.length && !/\n$/.test(text)) {
+                        insert_macro_text("\n");
+                    }
+                }
+                insert_macro_text("\n");
+            }
+        }).listen("paste", (event) => {
+            event.preventDefault();
+            insert_macro_text(event.clipboardData.getData("text/plain"));
+        });
 
         const macros_pane = new DOM.Div({ id: "macros-pane", class: "pane hidden" })
             .add(new DOM.Element("h1").add("Custom Macros"))
             .add(new DOM.Element("p").add("Use this editor to define custom LaTeX commands and colours."))
             .add(this.macros_input)
             .add(new DOM.Element("button").add("Apply Definitions").listen("click", () => {
-                this.macro_text = this.macros_input.element.value;
+                this.macro_text = this.macros_input.element.textContent;
                 this.load_macros(this.macro_text);
                 this.dismiss_pane();
             }));
@@ -3010,7 +3040,7 @@ class UI {
     /// actions (primarily keyboard shortcuts) will be disabled.)
     input_is_active() {
         // This may not be the label input, e.g. it may be the macros input.
-        return document.activeElement.matches('input[type="text"], div[contenteditable], textarea')
+        return document.activeElement.matches('input[type="text"], div[contenteditable]')
             && document.activeElement;
     }
 

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -5604,23 +5604,47 @@ class Panel {
             new DOM.Div({ class: "indicator-container katex-only" }).add(
                 new DOM.Element("label").add("Macros: ")
                     .add(
-                        new DOM.Element("input", {
-                            type: "text",
-                            placeholder: "Paste URL here",
-                        }).listen("wheel", (event) => {
-                            event.stopImmediatePropagation();
-                        }, { passive: true }).listen("keydown", (event, input) => {
-                            if (event.key === "Enter") {
-                                event.stopPropagation();
-                                ui.load_macros_from_url(input.value);
-                                input.blur();
-                            }
-                        }).listen("paste", (_, input) => {
-                            delay(() => ui.load_macros_from_url(input.value));
-                        })
-                    ).add(
-                        new DOM.Div({ class: "success-indicator" })
+                        new DOM.Element("a", { class: "help-button", title: "Help", href: "#", style: "margin-left: 4px; color: var(--ui-grey); text-decoration: none;" }).add("(?)")
+                            .listen("click", (event) => {
+                                event.preventDefault();
+                                const pane = ui.element.query_selector("#macros-help-pane");
+                                const is_hidden = pane.class_list.contains("hidden");
+                                ui.dismiss_pane();
+                                ui.panel.dismiss_port_pane(ui);
+                                if (is_hidden) {
+                                    pane.class_list.remove("hidden");
+                                }
+                            })
                     )
+            ).add(
+                new DOM.Element("input", {
+                    type: "text",
+                    placeholder: "Paste URL here",
+                }).listen("wheel", (event) => {
+                    event.stopImmediatePropagation();
+                }, { passive: true }).listen("keydown", (event, input) => {
+                    if (event.key === "Enter") {
+                        event.stopPropagation();
+                        ui.load_macros_from_url(input.value);
+                        input.blur();
+                    }
+                }).listen("paste", (_, input) => {
+                    delay(() => ui.load_macros_from_url(input.value));
+                })
+            ).add(
+                new DOM.Element("button", { style: "margin-left: 4px; padding: 2px 6px;" }).add("Edit")
+                    .listen("click", () => {
+                        const pane = ui.element.query_selector("#macros-pane");
+                        const is_hidden = pane.class_list.contains("hidden");
+                        ui.dismiss_pane();
+                        ui.panel.dismiss_port_pane(ui);
+                        if (is_hidden) {
+                            ui.macros_input.element.value = ui.macro_text || "";
+                            pane.class_list.remove("hidden");
+                        }
+                    })
+            ).add(
+                new DOM.Div({ class: "success-indicator" })
             )
         );
 

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -732,6 +732,9 @@ class UI {
         // The URL from which the macros have been fetched (if at all).
         this.macro_url = null;
 
+        // The macro definitions inserted by the user.
+        this.macro_text = null;
+
         // The user settings, which are stored persistently across sessions in `localStorage`.
         this.settings = new Settings();
     }
@@ -793,9 +796,10 @@ class UI {
     /// Returns options that are not saved persistently in `settings`, but are used to modify
     /// export output.
     options() {
-        const { macro_url } = this;
+        const { macro_url, macro_text } = this;
         return {
             macro_url,
+            macro_text,
             dimensions: this.diagram_size(),
             sep: this.panel.sep,
         };
@@ -8290,6 +8294,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 // If there is a `macro_url`, load the macros from it.
                 if (query_data.has("macro_url")) {
                     ui.load_macros_from_url(decodeURIComponent(query_data.get("macro_url")));
+                }
+                // If there are directly embedded macros, load them.
+                if (query_data.has("macros")) {
+                    ui.macro_text = decodeURIComponent(query_data.get("macros"));
+                    ui.load_macros(ui.macro_text);
                 }
                 // Adjust the diagram scale to fit the screen in embedded view.
                 // However, we have to be careful to only do this if the user

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -737,6 +737,15 @@ class UI {
         // The URL from which the macros have been fetched (if at all).
         this.macro_url = null;
 
+        // The macro definitions inserted by the user.
+        this.macro_text = null;
+
+        // The macro definitions most recently loaded from `macro_url`.
+        this.macro_url_text = null;
+
+        // A monotonically increasing ID used to ignore stale macro URL fetch results.
+        this.macro_update_number = 0;
+
         // The user settings, which are stored persistently across sessions in `localStorage`.
         this.settings = new Settings();
 
@@ -813,6 +822,7 @@ class UI {
         }
         return {
             macro_url: this.macro_url,
+            macro_text: this.macro_text,
             dimensions: this.diagram_size(),
             sep: this.panel.sep,
             scale
@@ -1165,6 +1175,73 @@ class UI {
                 .add(".")
             );
         panes.push(welcome_pane);
+
+        // Set up the macros pane.
+        const macro_url_input = new DOM.Element("input", {
+            type: "text",
+            placeholder: "Paste URL here",
+        });
+        const macros_input = new DOM.Element("textarea", { spellcheck: "false" });
+
+        macro_url_input.listen("wheel", (event) => {
+            event.stopImmediatePropagation();
+        }, { passive: true }).listen("keydown", (event, input) => {
+            if (event.key === "Enter") {
+                event.stopPropagation();
+                this.load_macros_from_url(input.value);
+                input.blur();
+            }
+            if (event.key === "Tab") {
+                macros_input.element.focus();
+            }
+        }).listen("paste", (_, input) => {
+            delay(() => this.load_macros_from_url(input.value));
+        });
+
+        macros_input.listen("wheel", (event) => {
+            event.stopImmediatePropagation();
+        }, { passive: true }).listen("keydown", (event) => {
+            if (event.key === "Enter") {
+                event.stopPropagation();
+            }
+            if (event.key === "Tab") {
+                macro_url_input.element.focus();
+            }
+        }).listen("input", (event) => {
+            const macro_text = macros_input.element.value.trim();
+            if (macro_text !== this.macro_url_text) {
+                // Inline edits take precedence and invalidate URL fetches in flight.
+                ++this.macro_update_number;
+                this.macro_text = macro_text;
+                // We deliberately do not reset `this.macro_url` and `this.macro_url_text`, so that
+                // if the user edits the macros manually, but then reverts the changes, we can
+                // simply export the macro URL instead of all the text.
+                this.load_macros(macro_text);
+            } else {
+                this.macro_text = null;
+            }
+        });
+
+        this.macros_pane = new DOM.Div({ class: "pane hidden" })
+            .add(new DOM.Element("h1").add("Custom macros"))
+            .add(new DOM.Element("p")
+                .add("Paste a URL below to load custom macros and colours:")
+            )
+            .add(macro_url_input)
+            .add(new DOM.Element("p").add("Or input them below (one definition per line):"))
+            .add(macros_input)
+            .add(
+                new DOM.Element("p")
+                    .add("See the ")
+                    .add(new DOM.Link(
+                        "https://github.com/varkor/quiver/blob/master/tutorial.md#importing-macros-and-colours",
+                        "documentation",
+                        true,
+                    ))
+                    .add(" for more information.")
+            );
+        panes.push(this.macros_pane);
+
         new DOM.Element("button").add("Get started").listen("click", () => {
             // There are technically other ways to dismiss the welcome pane (e.g. opening the
             // keyboard shortcuts pane without clicking this button). We choose not to set the
@@ -3000,7 +3077,7 @@ class UI {
     /// actions (primarily keyboard shortcuts) will be disabled.)
     input_is_active() {
         // This may not be the label input, e.g. it may be the macros input.
-        return document.activeElement.matches('input[type="text"], div[contenteditable]')
+        return document.activeElement.matches('input[type="text"], div[contenteditable], textarea')
             && document.activeElement;
     }
 
@@ -3463,42 +3540,54 @@ class UI {
 
     /// Load macros from a URL.
     load_macros_from_url(url) {
+        // Cancel any in-flight URL fetches.
+        const macro_update_number = ++this.macro_update_number;
         // Reset the stored macro URL. We don't want to store outdated URLs, but we also don't
         // want to store invalid URLs, so we'll set `this.macro_url` when we succeed in fetching the
         // definitions.
         this.macro_url = null;
+        this.macro_url_text = null;
 
-        const macro_input = this.panel.global.query_selector("input");
+        const macro_url_input = this.macros_pane.query_selector('input[type="text"]');
         url = url.trim();
-        macro_input.element.value = url;
-
-        const success_indicator = macro_input.parent.query_selector(".success-indicator");
-        success_indicator.class_list.remove("success", "failure");
+        macro_url_input.element.value = url;
+        const macro_input = this.macros_pane.query_selector("textarea");
 
         // Clear the error banner if it's an error caused by a previous failure of
         // `load_macros`.
         UI.dismiss_error("macro-load");
 
         if (url !== "") {
-            success_indicator.class_list.add("unknown");
             // CORS is terribly frustrating. We simply want to fetch some text, but are often
             // unable to do so, because CORS is opt-in and most sites have not. To alleviate this
             // problem, we try to prefix URLs that failed to load with the following service
             // (which should surely not be necessary with `credentials: "omit"`). In doing so, we
             // are hoping that the service never becomes malicious.
-            const CORS_PROXY = "https://api.allorigins.win/raw?url=";
+            const CORS_PROXY = "https://proxy.cors.sh/";
 
             const attempt_to_fetch_macros = (url, prefix = "", repeat = true) => {
                 fetch(`${prefix}${url}`, { credentials: "omit" })
-                    .then((response) => response.text())
+                    .then((response) => {
+                        if (response.ok) {
+                            return response.text();
+                        }
+                        return Response.error();
+                    })
                     .then((text) => {
+                        if (macro_update_number !== this.macro_update_number) {
+                            return;
+                        }
                         this.load_macros(text);
+                        this.macro_text = null;
                         this.macro_url = url;
-                        success_indicator.class_list.remove("unknown");
-                        success_indicator.class_list.add("success");
-                        macro_input.element.blur();
+                        this.macro_url_text = text.trim();
+                        macro_input.element.value = this.macro_url_text;
+                        macro_url_input.element.blur();
                     })
                     .catch(() => {
+                        if (macro_update_number !== this.macro_update_number) {
+                            return;
+                        }
                         if (repeat && !url.startsWith(CORS_PROXY)) {
                             // Attempt to fetch using cors-anywhere.
                             attempt_to_fetch_macros(url, CORS_PROXY, false);
@@ -3509,12 +3598,13 @@ class UI {
                             "from the given URL.",
                             "macro-load",
                         );
-                        success_indicator.class_list.remove("unknown");
-                        success_indicator.class_list.add("failure");
                     });
             };
             attempt_to_fetch_macros(url);
         } else {
+            this.macro_text = null;
+            macro_input.element.value = "";
+
             // If the URL is empty, we simply reset all macro and colour definitions (as if the user
             // had never loaded any macros or colours).
             this.macros = new Map();
@@ -4287,12 +4377,11 @@ class Panel {
             }
         });
 
-        const add_button = (title, label, key, action) => {
-            const button
-                = Panel.create_button_with_shortcut(ui, title, label, { key }, (event) => {
-                    this.unqueue_selected(ui);
-                    return action(event);
-                });
+        const add_button = (label, key, action) => {
+            const button = Panel.create_button_with_shortcut(ui, label, { key }, (event) => {
+                this.unqueue_selected(ui);
+                return action(event);
+            });
             button.set_attributes({ disabled: true });
             button.add_to(wrapper);
         };
@@ -5681,7 +5770,6 @@ class Panel {
         // The import button.
         const import_from_tikz = Panel.create_button_with_shortcut(
             ui,
-            "tikz-cd diagram",
             "tikz-cd",
             { key: "I", modifier: true, context: Shortcuts.SHORTCUT_PRIORITY.Always },
             () => {
@@ -5695,7 +5783,6 @@ class Panel {
         const export_to_latex = Panel.create_button_with_shortcut(
             ui,
             "LaTeX",
-            "LaTeX",
             { key: "E", modifier: true, context: Shortcuts.SHORTCUT_PRIORITY.Always },
             () => {
                 if (ui.settings.get("quiver.renderer") === "katex") {
@@ -5705,7 +5792,6 @@ class Panel {
         ).set_attributes({ class: "katex-only" });
         const export_to_typst = Panel.create_button_with_shortcut(
             ui,
-            "Typst",
             "Typst",
             { key: "E", modifier: true, context: Shortcuts.SHORTCUT_PRIORITY.Always },
             () => {
@@ -5753,11 +5839,25 @@ class Panel {
             }
         });
 
-        this.global = new DOM.Div({ class: "panel global" }).add(
-            new DOM.Element("label").add("Renderer: ")
-        ).add(renderer_select).add(
+        this.global = new DOM.Div({ class: "panel global" })
+        .add(renderer_select).add(
             new DOM.Element("label").add("Import: ").set_attributes({ "class": "katex-only" })
-        ).add(import_from_tikz).add(
+        ).add(import_from_tikz)
+        .add(new DOM.Element("button", { class: "katex-only" }).add("Macros")
+            .listen("click", () => {
+                const is_hidden = ui.macros_pane.class_list.contains("hidden");
+                if (!ui.panel.dismiss_port_pane(ui)) {
+                    ui.dismiss_pane();
+                }
+                if (is_hidden) {
+                    ui.macros_pane.query_selector("textarea").element.value = ui.macro_text
+                        || ui.macro_url_text
+                        || "";
+                    ui.macros_pane.class_list.remove("hidden");
+                    ui.macros_pane.query_selector('input[type="text"]').element.focus();
+                }
+            })
+        ).add(
             new DOM.Element("label").add("Export: ")
         ).add(
             // The shareable link button.
@@ -5771,29 +5871,8 @@ class Panel {
               .listen("click", () => {
                   display_port_pane("export", "html");
               })
-        ).add(export_to_latex).add(export_to_typst).add(
-            new DOM.Div({ class: "indicator-container katex-only" }).add(
-                new DOM.Element("label").add("Macros: ")
-                    .add(
-                        new DOM.Element("input", {
-                            type: "text",
-                            placeholder: "Paste URL here",
-                        }).listen("wheel", (event) => {
-                            event.stopImmediatePropagation();
-                        }, { passive: true }).listen("keydown", (event, input) => {
-                            if (event.key === "Enter") {
-                                event.stopPropagation();
-                                ui.load_macros_from_url(input.value);
-                                input.blur();
-                            }
-                        }).listen("paste", (_, input) => {
-                            delay(() => ui.load_macros_from_url(input.value));
-                        })
-                    ).add(
-                        new DOM.Div({ class: "success-indicator" })
-                    )
-            )
-        );
+        ).add(export_to_latex)
+        .add(export_to_typst);
 
         // Prevent propagation of pointer events when interacting with the global options.
         this.global.listen(pointer_event("down"), (event) => {
@@ -5804,10 +5883,8 @@ class Panel {
     }
 
     /// Creates a UI button with an associated keyboard shortcut.
-    static create_button_with_shortcut(ui, title, label, shortcut, action) {
-        const button = new DOM.Element("button", { title })
-            .add(label)
-            .listen("click", action);
+    static create_button_with_shortcut(ui, label, shortcut, action) {
+        const button = new DOM.Element("button").add(label).listen("click", action);
         ui.shortcuts.add([shortcut], (event) => {
             if (!button.element.disabled) {
                 action(event);
@@ -8584,8 +8661,13 @@ document.addEventListener("DOMContentLoaded", () => {
             try {
                 // Decode the diagram.
                 QuiverImportExport.base64.import(ui, query_data.get("q"));
-                // If there is a `macro_url`, load the macros from it.
-                if (query_data.has("macro_url")) {
+                // If there are directly embedded macros, prefer them, to avoid URL fetch races.
+                if (query_data.has("macros")) {
+                    ++ui.macro_update_number;
+                    ui.macro_text = decodeURIComponent(query_data.get("macros")).trim();
+                    ui.load_macros(ui.macro_text);
+                // Otherwise, if there is a `macro_url`, load the macros from it.
+                } else if (query_data.has("macro_url")) {
                     ui.load_macros_from_url(decodeURIComponent(query_data.get("macro_url")));
                 }
                 // Adjust the diagram scale to fit the screen in embedded view.

--- a/tutorial.md
+++ b/tutorial.md
@@ -130,16 +130,14 @@ Note that you will need to have the [`quiver.sty` package](https://raw.githubuse
 
 ## Importing macros and colours
 
-To use custom macros and colours in **quiver**, create a text file containing the definitions (for instance, the following).
+To use custom macros and colours in **quiver**, create a text file containing each of definitions, one per line. For instance:
 
 ```latex
-\newcommand{\cat}{\mathscr}
-\newcommand{\psh}{\widehat}
-\newcommand{\smcat}{\mathbb}
 \newcommand{\yo}{よ}
+\definecolor{redchalk}{RGB}{214, 92, 92}
 ```
 
-Upload the file to a publicly accessible URL (for instance, [gist.github.com](https://gist.github.com/)), and paste the URL for the raw text into the **Macros** input at the bottom of **quiver**.
+Upload the file to a publicly accessible URL (for instance, [gist.github.com](https://gist.github.com/)). Next, click the **Macros** button in the toolbar at the bottom, and paste the URL for the raw text into the input field. Alternatively, you can type or paste the definitions directly into the text area.
 
 Currently, macros may be defined using `\newcommand`, `\newcommand*`, `\renewcommand`, `\renewcommand*`, `\DeclareMathOperator`, and `\DeclareMathOperator*`; and colours may be defined using `\definecolor` (using the colour modes: `rgb`, `RGB`, `HTML`, `gray`).
 
@@ -168,7 +166,8 @@ The `quiver.sty` package is available [on GitHub](https://raw.githubusercontent.
 For convenience, the query parameters supported by **quiver** are the following.
 
 - `embed`: enables embedded mode, for displaying in an `<iframe>`. Expects no value. In this mode, editing the diagram is disabled, as well as various interface elements.
-- `macro_url`: a URL to load macros from. Expects a URL.
+- `macros`: a string containing macro definitions. If both `macros` and `macro_url` are present, `macros` takes precedence.
+- `macro_url`: a URL to load macros from.
 - `q`: the diagram to load. Expects an encoded diagram, as exported by **quiver**.
 - `r`: sets the renderer. Expects either `katex` or `typst`.
 - `scale`: sets the initial zoom level. Expects any integer. For instance: `0` corresponds to the default zoom; `1` is zoomed in 2x; `-1` is zoomed out 2x. This is primarily intended to be used with embedded mode.


### PR DESCRIPTION
I faced similar confusion with #296 and #226 when I first started using quiver 

So I've implemented support for defining and editing custom LaTeX macros directly within the application. Users can now enter, edit, and apply custom macro definitions, and these macros are included in exports and can be loaded from shared URLs.

The customised macros work just like the imported ones:
https://github.com/user-attachments/assets/77e9621b-3bf5-431b-a4ba-3c02adc0d4b0

Currently, the customised macros will be overwritten by those imported from URL. The imported macros are also displayed in the edit field. Once edited, the export link will be updated.

https://github.com/user-attachments/assets/f962c34d-0f9e-4441-954c-de272ffe25e1
